### PR TITLE
Add Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: ruby
+cache: bundler
+script: bundle exec middleman build


### PR DESCRIPTION
Add a basic Travis config file to set up continuous integration for the GOV.UK Frontend Docs.

Closes https://github.com/alphagov/govuk-frontend-docs/issues/5