### PR TITLE
Fix style in Sass API reference title

### DIFF
--- a/source/sass_api_reference/index.html.md.erb
+++ b/source/sass_api_reference/index.html.md.erb
@@ -1,9 +1,9 @@
 ---
-title: Sass API Reference
+title: Sass API reference
 weight: 65
 ---
 
-# Sass API Reference
+# Sass API reference
 
 <% format_sassdoc_data(data).each do |heading, group| %>
 


### PR DESCRIPTION
This replaces the uppercase 'R' in 'Sass API Reference' with a lowercase 'r', to match GOV.UK style.