### PR TITLE
Add basic authentication to cloudapps.digital domain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 /.bundle
 
 # Ignore the build directory
-/build
+/deploy/public
 
 # Ignore cache
 /.sass-cache

--- a/config.rb
+++ b/config.rb
@@ -1,6 +1,8 @@
 require "govuk_tech_docs"
 require "sassdocs_helpers"
 
+config[:build_dir] = 'deploy/public'
+
 GovukTechDocs.configure(self)
 
 helpers do

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -1,0 +1,140 @@
+# Unfortunately the staticfile buildpack has some limitations (e.g. it's hard to
+# implement cache control because you can only add configuration to the location
+# block) so we have to roll our own nginx configuration.
+#
+# A lot of this is based on the nginx configuration from the 'example' nginx
+# buildpack [1] and the staticfile buildpack [2]
+#
+# [1]: https://github.com/cloudfoundry/nginx-buildpack/blob/d777ce54d4641a821d493a2d8d4661b07d53e735/fixtures/mainline/nginx.conf
+# [2]: https://github.com/cloudfoundry/staticfile-buildpack/blob/05867b82df7e5f6f1155ce193a424a79693967bb/src/staticfile/finalize/data.go
+
+worker_processes 1;
+daemon off;
+
+error_log stderr;
+events { worker_connections 1024; }
+
+http {
+  charset utf-8;
+
+  # Configure logging
+
+  log_format cloudfoundry 'NginxLog "$request" $status $body_bytes_sent';
+  access_log /dev/stdout cloudfoundry;
+
+  # MIME types and default MIME types
+
+  default_type application/octet-stream;
+  include nginx/mime.types;
+  charset_types text/html text/xml text/plain application/javascript application/rss+xml text/css;
+
+  # Enabling sendfile eliminates copying file data into buffer and sends it
+  # directly
+
+  sendfile on;
+
+  # Enable gzip for text-based resources
+
+  gzip on;
+  gzip_disable "msie6";
+  gzip_comp_level 6;
+  gzip_min_length 1100;
+  gzip_buffers 16 8k;
+  gzip_proxied any;
+  gunzip on;
+  gzip_static always;
+  gzip_types text/plain text/css text/js text/xml text/javascript application/javascript application/x-javascript application/json application/xml application/xml+rss;
+  gzip_vary on;
+
+  # Yeah, like, networking stuff ¯\_(ツ)_/¯
+
+  tcp_nopush on;
+  keepalive_timeout 30;
+
+  # Disable absolute redirects
+  #
+  # The index directive (1) used in the nginx config within the buildpack means
+  # that we send a 301 redirect when visiting a directory without a trailing
+  # slash (e.g. /design-system will redirect to /design-system/).
+  # 
+  # However by default nginx will use absolute URLs – including the hostname –
+  # when redirecting, which means that users going to
+  # design-system.service.gov.uk/components will end up being redirected to our
+  # 'origin domain' (govuk-design-system-origin.cloudapps.digital/components/)
+  # which is less than ideal.
+  #
+  # Disabling absolute redirects (2) means that nginx will instead 301 to the
+  # relative url /design-system, which means users won't be redirected away from
+  # the service domain and everything is A-OK ✌️
+  #
+  # [1]: http://nginx.org/en/docs/http/ngx_http_index_module.html#index
+  # [2]: http://nginx.org/en/docs/http/ngx_http_core_module.html#absolute_redirect
+
+  absolute_redirect off;
+
+  # Ensure that redirects don't include the port which nginx is using inside the
+  # CloudFoundry container
+
+  port_in_redirect off;
+
+  # Send different expires headers depending on the content-type of the resource
+  # we're returning. It should be safe to cache fonts 'indefinitely' as they
+  # should include fingerprints in their filenames.
+  #
+  # Because images and videos are not fingerprinted we only cache them for 30
+  # minutes.
+  # 
+  # The epoch parameter corresponds to the absolute time
+  # 'Thu, 01 Jan 1970 00:00:01 GMT'.
+
+  map $sent_http_content_type $expires {
+    default                         off;
+    text/html                       epoch;
+    text/css                        off;
+    application/javascript          off;
+    application/json                off;
+    ~application/x-font             max;
+    ~application/font               max;
+    application/vnd.ms-fontobject   max;
+    ~image/                         30m;
+    ~video/                         30m;
+  }
+
+  expires $expires;
+
+  # Determine whether to use authentication based on what host the request is
+  # made against - 'off' is a special value that disables basic authentication
+  # when passed to the auth_basic directive.
+
+  map $host $auth_enabled {
+    hostnames;
+
+    default "Restricted";
+    frontend.design-system.service.gov.uk "off";
+  }
+
+  # Set up a server!
+
+  server {
+    listen {{port}} default_server;
+
+    root public;
+
+    location / {
+      index index.html index.htm;
+
+      # Configure basic authentication - this is disabled on the service domain.
+      # See above definition of $auth_enabled using the map directive.
+
+      auth_basic $auth_enabled;
+      auth_basic_user_file nginx/.htpasswd;
+
+      # Avoid serving hidden ('dot') files
+
+      location ~ /\. {
+        deny all;
+        return 404;
+      }
+    }
+  }
+}

--- a/deploy/nginx/.htpasswd
+++ b/deploy/nginx/.htpasswd
@@ -1,0 +1,1 @@
+origin:$apr1$lc1xPZfR$bkg2bwTNU2eEwNIoZTf4l.

--- a/deploy/nginx/mime.types
+++ b/deploy/nginx/mime.types
@@ -1,0 +1,92 @@
+types {
+    text/html                             html htm shtml;
+    text/css                              css;
+    text/xml                              xml;
+    image/gif                             gif;
+    image/jpeg                            jpeg jpg;
+    application/javascript                js;
+    application/atom+xml                  atom;
+    application/rss+xml                   rss;
+
+    text/mathml                           mml;
+    text/plain                            txt;
+    text/vnd.sun.j2me.app-descriptor      jad;
+    text/vnd.wap.wml                      wml;
+    text/x-component                      htc;
+
+    image/png                             png;
+    image/tiff                            tif tiff;
+    image/vnd.wap.wbmp                    wbmp;
+    image/x-icon                          ico;
+    image/x-jng                           jng;
+    image/x-ms-bmp                        bmp;
+    image/svg+xml                         svg svgz;
+    image/webp                            webp;
+
+    application/x-font-ttf                ttc ttf;
+    application/x-font-otf                otf;
+    application/font-woff                 woff;
+    application/font-woff2                woff2;
+    application/vnd.ms-fontobject         eot;
+
+    application/java-archive              jar war ear;
+    application/json                      json;
+    application/mac-binhex40              hqx;
+    application/msword                    doc;
+    application/pdf                       pdf;
+    application/postscript                ps eps ai;
+    application/rtf                       rtf;
+    application/vnd.apple.mpegurl         m3u8;
+    application/vnd.ms-excel              xls;
+    application/vnd.ms-powerpoint         ppt;
+    application/vnd.wap.wmlc              wmlc;
+    application/vnd.google-earth.kml+xml  kml;
+    application/vnd.google-earth.kmz      kmz;
+    application/x-7z-compressed           7z;
+    application/x-cocoa                   cco;
+    application/x-java-archive-diff       jardiff;
+    application/x-java-jnlp-file          jnlp;
+    application/x-makeself                run;
+    application/x-perl                    pl pm;
+    application/x-pilot                   prc pdb;
+    application/x-rar-compressed          rar;
+    application/x-redhat-package-manager  rpm;
+    application/x-sea                     sea;
+    application/x-shockwave-flash         swf;
+    application/x-stuffit                 sit;
+    application/x-tcl                     tcl tk;
+    application/x-x509-ca-cert            der pem crt;
+    application/x-xpinstall               xpi;
+    application/xhtml+xml                 xhtml;
+    application/xspf+xml                  xspf;
+    application/zip                       zip;
+
+    application/octet-stream              bin exe dll;
+    application/octet-stream              deb;
+    application/octet-stream              dmg;
+    application/octet-stream              iso img;
+    application/octet-stream              msi msp msm;
+
+    application/vnd.openxmlformats-officedocument.wordprocessingml.document    docx;
+    application/vnd.openxmlformats-officedocument.spreadsheetml.sheet          xlsx;
+    application/vnd.openxmlformats-officedocument.presentationml.presentation  pptx;
+
+    audio/midi                            mid midi kar;
+    audio/mpeg                            mp3;
+    audio/ogg                             ogg;
+    audio/x-m4a                           m4a;
+    audio/x-realaudio                     ra;
+
+    video/3gpp                            3gpp 3gp;
+    video/mp2t                            ts;
+    video/mp4                             mp4;
+    video/mpeg                            mpeg mpg;
+    video/quicktime                       mov;
+    video/webm                            webm;
+    video/x-flv                           flv;
+    video/x-m4v                           m4v;
+    video/x-mng                           mng;
+    video/x-ms-asf                        asx asf;
+    video/x-ms-wmv                        wmv;
+    video/x-msvideo                       avi;
+}

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,10 +1,11 @@
 ---
 applications:
 - name: govuk-frontend-docs
-  path: build
+  path: ./deploy
   memory: 64M
   instances: 2
-  buildpack: staticfile_buildpack
+  # https://docs.cloud.service.gov.uk/deploying_apps.html#how-to-use-custom-buildpacks
+  buildpack: https://github.com/cloudfoundry/nginx-buildpack.git#v1.1.7
 
   routes:
     - route: govuk-frontend-docs.cloudapps.digital


### PR DESCRIPTION
Switch to using the nginx buildpack to allow us to selectively enable basic authentication when visiting via the cloudapps.digital route.

Closes #25 