### PR TITLE
Remove path to app from deploy script

### DIFF
--- a/bin/deploy-travis
+++ b/bin/deploy-travis
@@ -10,4 +10,4 @@ APP_NAME=$(ruby -e "require 'yaml'; config = YAML.load_file('manifest.yml'); put
 cf v3-create-app $APP_NAME
 cf v3-apply-manifest -f manifest.yml
 # Deploy using CloudFoundry zero-downtime push
-cf v3-zdt-push $APP_NAME -p build --wait-for-deploy-complete
+cf v3-zdt-push $APP_NAME --wait-for-deploy-complete


### PR DESCRIPTION
By default, CloudFoundry should deploy using the path defined in the manifest file. Remove it from the deploy script to avoid the two getting out of sync.