### PR TITLE
Use path from manifest

### DIFF
--- a/bin/deploy-travis
+++ b/bin/deploy-travis
@@ -6,8 +6,9 @@ cf target -o $CF_ORG -s $CF_SPACE
 
 # Parse app name from manifest to ensure it matches up
 APP_NAME=$(ruby -e "require 'yaml'; config = YAML.load_file('manifest.yml'); puts config['applications'][0]['name']")
+PATH=$(ruby -e "require 'yaml'; config = YAML.load_file('manifest.yml'); puts config['applications'][0]['path']")
 
 cf v3-create-app $APP_NAME
 cf v3-apply-manifest -f manifest.yml
 # Deploy using CloudFoundry zero-downtime push
-cf v3-zdt-push $APP_NAME --wait-for-deploy-complete
+cf v3-zdt-push $APP_NAME -p $PATH --wait-for-deploy-complete


### PR DESCRIPTION
It looks as though the v3-zdt-push command ignores the manifest file, so we do need to specify the path separately using `-p`. To avoid having it defined in two places, we can read it out of the manifest in the same way that we get the app name.

Third time's the charm…