### PR TITLE
Add 404 and generic error pages

### DIFF
--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -123,6 +123,11 @@ http {
     location / {
       index index.html index.htm;
 
+       # Configure error pages
+
+      error_page 404 /errors/404.html;
+      error_page 400 401 402 403 405 406 407 408 409 410 411 412 413 414 415 416 417 418 420 422 423 424 426 428 429 431 444 449 450 451 500 501 502 503 504 505 506 507 508 509 510 511 /errors/generic.html;
+
       # Configure basic authentication - this is disabled on the service domain.
       # See above definition of $auth_enabled using the map directive.
 

--- a/source/errors/404.html.md.erb
+++ b/source/errors/404.html.md.erb
@@ -1,0 +1,15 @@
+---
+title: Page not found
+hide_from_sitemap: true
+hide_in_navigation: true
+index: false
+layout: core
+---
+
+# Page not found
+
+If you typed the web address, check it is correct.
+
+If you pasted the web address, check you copied the entire address.
+
+[Contact the Design System team](https://design-system.service.gov.uk/get-in-touch/) if you believe you are seeing this message in error.

--- a/source/errors/generic.html.md.erb
+++ b/source/errors/generic.html.md.erb
@@ -1,0 +1,13 @@
+---
+title: Sorry, there is a problem with the service
+hide_from_sitemap: true
+hide_in_navigation: true
+index: false
+layout: core
+---
+
+# Sorry, there is a problem with the service.
+
+Try again later.
+
+[Contact the Design System team](https://design-system.service.gov.uk/get-in-touch/) if you believe you are seeing this message in error.


### PR DESCRIPTION
This adds a 404 and a generic error page. The content of the pages follows what we use in the Design System website.

We include `index: false` in frontmatter to remove the pages from the site search.

I've tested the 404 page by pushing to the sandbox to see it gets picked up there.

Fixes https://github.com/alphagov/govuk-frontend-docs/issues/26