### PR TITLE
Use full name in page title

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -4,6 +4,7 @@ host:
 # Header-related options
 show_govuk_logo: true
 service_name: Frontend
+full_service_name: GOV.UK Frontend
 service_link: https://frontend.design-system.service.gov.uk/
 phase: Beta
 


### PR DESCRIPTION
Set the full service name in the config so that the page titles are correct, for example 'GOV.UK Frontend' rather than 'GOV.UK Frontend | Frontend'.