### PR TITLE
Ensure non-master preview builds are not indexed

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -5,6 +5,9 @@ config[:build_dir] = 'deploy/public'
 
 GovukTechDocs.configure(self)
 
+# Prevent pages from being indexed unless Travis is building the master branch
+config[:tech_docs][:prevent_indexing] = (ENV['TRAVIS_BRANCH'] != 'master')
+
 helpers do
   include SassdocsHelpers
   def markdown(content = nil)

--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -32,8 +32,8 @@ collapsible_nav: true
 # headings.
 max_toc_heading_level: 2
 
-# Prevent robots from indexing (e.g. whilst in development)
-prevent_indexing: false
+# Set dynamically in config.rb depending on TRAVIS_BRANCH
+# prevent_indexing: false
 
 show_contribution_banner: true
 github_repo: alphagov/govuk-frontend-docs


### PR DESCRIPTION
Make Netlify previews (or generally anything that's not the master branch) non-indexable by search engines so that users aren't confused by finding previews of PRs.

Fixes https://github.com/alphagov/govuk-frontend-docs/issues/10