### PR TITLE
Bind logit-ssl-drain service to app

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -7,6 +7,11 @@ applications:
   # https://docs.cloud.service.gov.uk/deploying_apps.html#how-to-use-custom-buildpacks
   buildpack: https://github.com/cloudfoundry/nginx-buildpack.git#v1.1.7
 
+  # Send application logs to logit
+  # https://docs.cloud.service.gov.uk/monitoring_apps.html#configure-app
+  services:
+    - logit-ssl-drain
+
   routes:
     - route: govuk-frontend-docs.cloudapps.digital
     - route: frontend.design-system.service.gov.uk


### PR DESCRIPTION
Send logs to the existing logit-ssl-drain service we use for the Design System, by binding the service to the app.

This means that the logs will end up in the same Logit instance as the Design System logs, but we can easily filter the logs and the dashboards by app name.

Part of #27 