### PR TITLE
Add host to tech docs configuration

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -1,11 +1,11 @@
 # Host to use for canonical URL generation (without trailing slash)
-host:
+host: https://frontend.design-system.service.gov.uk
 
 # Header-related options
 show_govuk_logo: true
 service_name: Frontend
 full_service_name: GOV.UK Frontend
-service_link: https://frontend.design-system.service.gov.uk/
+service_link: /
 phase: Beta
 
 # Links to show on right-hand-side of header


### PR DESCRIPTION
Including the host in the config means that the canonical URL and meta tags are generated correctly.