### PR TITLE
Add a page for CloundFoundry health checks

### DIFF
--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -140,6 +140,12 @@ http {
         deny all;
         return 404;
       }
+
+      # Allow health checks without authentication
+
+      location /canary.html {
+        auth_basic off;
+      }
     }
   }
 }

--- a/source/canary.html
+++ b/source/canary.html
@@ -1,0 +1,17 @@
+---
+layout: false
+hide_from_sitemap: true
+hide_in_navigation: true
+---
+
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="robots" content="noindex">
+    <title>200 OK</title>
+  </head>
+  <body>
+    Tweet tweet
+  </body>
+</html>


### PR DESCRIPTION
This PR:
- Creates a new HTML page which will be built and deployed to `/canary.html`, containing nothing but the words ‘Tweet tweet’ (following the pattern set by [GOV.UK](gov.uk/__canary__) and also used by the [Design System](design-system.service.gov.uk/__canary__/)).
- Turns off authentication off for `/canary.html` so that it can be accessed by the health checks.

Once this work is merged into master, we can merge in https://github.com/alphagov/govuk-frontend-docs/pull/50 which will add a health check to the manifest based on whether the canary page returns 200. See https://github.com/alphagov/govuk-frontend-docs/pull/50  for more details on the health check and why this work had to split into two PRs.