### PR TITLE
[WIP]Remove extraneous 'govuk' in path

### DIFF
--- a/source/get-started/index.html.md.erb
+++ b/source/get-started/index.html.md.erb
@@ -32,7 +32,7 @@ Paste the HTML into a page or template in your application.
 1. Add the following to the main Sass file in your project, so your Sass compiler adds all of GOV.UK Frontend's styles to your CSS file.
 
     ```Scss
-    @import "node_modules/govuk-frontend/govuk/all";
+    @import "node_modules/govuk-frontend/all";
     ```
 
 2. Add your CSS file to your page layout if you need to. For example:
@@ -56,8 +56,8 @@ Your component will not use the right font or images until you've added GOV.UK F
 
 1. Copy the following 2 folders:
 
-- `/node_modules/govuk-frontend/govuk/assets/images` folder to `<YOUR-APP>/assets/images`
-- `/node_modules/govuk-frontend/govuk/assets/fonts` folder to `<YOUR-APP>/assets/fonts`
+- `/node_modules/govuk-frontend/assets/images` folder to `<YOUR-APP>/assets/images`
+- `/node_modules/govuk-frontend/assets/fonts` folder to `<YOUR-APP>/assets/fonts`
 
 2. Run your application, then use [the Fonts tab in Firefox Page Inspector](https://developer.mozilla.org/en-US/docs/Tools/Page_Inspector/How_to/Edit_fonts#The_Fonts_tab) to check the accordion is using the GDS Transport font.
 
@@ -71,7 +71,7 @@ In your live application, we recommend [using an automated task or your build pi
     <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
     ```
 
-2. Copy the `/node-modules/govuk-frontend/govuk/all.js` file to `<YOUR-JAVASCRIPT-FOLDER>/govuk.js`.
+2. Copy the `/node-modules/govuk-frontend/all.js` file to `<YOUR-JAVASCRIPT-FOLDER>/govuk.js`.
 
 3. Import the file before the closing `</body>` tag of your page template, then run the `initAll` function to initialise all the components. For example:
 


### PR DESCRIPTION
Hi team,

I've just installed this now using npm for a bit of bank holiday mucking about, and I noticed that the `node_modules` folder doesn't have a `govuk` subfolder. I'm not sure if I've installed it incorrectly, but in case I've spotted a minor bug I've written this tiny PR to update the docs.