### PR TITLE
Add health checks for CloudFoundry deployments

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -2,6 +2,8 @@
 applications:
 - name: govuk-frontend-docs
   path: ./deploy
+  health-check-type: http
+  health-check-http-endpoint: /canary.html
   memory: 64M
   instances: 2
   # https://docs.cloud.service.gov.uk/deploying_apps.html#how-to-use-custom-buildpacks


### PR DESCRIPTION
Depends on https://github.com/alphagov/govuk-frontend-docs/pull/48.

This PR adds a health check to the deployment to check if `/canary.html` returns 200. This change had to be split in two PRs because the manifest will run the health check before doing the deployment - as our existing site doesn’t yet have the canary it would fail.

I paired with PaaS tech support to test what happens with a failed deploy. We verified that the already deployed site would continue to return 200 if an “unhealthy” deploy is attempted (our test case was deleting `deploy/public/canary.html`). 

I’m told by the PaaS team that V7 of [CloudFoundry CLI](https://github.com/cloudfoundry/cli) will make these steps in the deployment process much easier to manage as we’ll be able to do our Travis deploy in one line, instead of the current three 🤩

Fixes https://github.com/alphagov/govuk-frontend-docs/issues/28