### PR TITLE
Fix syntax highlighting

### DIFF
--- a/source/get-started/index.html.md.erb
+++ b/source/get-started/index.html.md.erb
@@ -31,7 +31,7 @@ Paste the HTML into a page or template in your application.
 
 1. Add the following to the main Sass file in your project, so your Sass compiler adds all of GOV.UK Frontend's styles to your CSS file.
 
-    ```Scss
+    ```scss
     @import "node_modules/govuk-frontend/govuk/all";
     ```
 

--- a/source/importing-css-assets-and-javascript/index.html.md.erb
+++ b/source/importing-css-assets-and-javascript/index.html.md.erb
@@ -11,7 +11,7 @@ weight: 70
 
 To import all the Sass rules from GOV.UK Frontend, add the following to your Sass file:
 
-```Scss
+```scss
 @import "node_modules/govuk-frontend/govuk/all";
 ```
 
@@ -19,7 +19,7 @@ To import all the Sass rules from GOV.UK Frontend, add the following to your Sas
 
 To import the [button](https://design-system.service.gov.uk/components/button/) component for example, add the following to your Sass file:
 
-```SCSS
+```scss
 @import "node_modules/govuk-frontend/govuk/components/button/button";
 ```
 
@@ -32,7 +32,7 @@ If you want to make Sass import paths shorter, add `node_modules/govuk-frontend`
 
 You can then import without using `node_modules/govuk-frontend/` in your import path. For example:
 
-```SCSS
+```scss
 @import "govuk/components/button/button";
 ```
 
@@ -82,13 +82,13 @@ Set one of the following before the `@import` line in your Sass file:
 
 Set the `$govuk-assets-path` variable if your `font` and `image` folders have the same parent folder. For example:
 
-```SCSS
+```scss
 $govuk-assets-path: '/<YOUR-ASSETS-FOLDER>';
 ```
 
 Set the `$govuk-images-path` and `$govuk-fonts-path` variables if your `font` and `image` folders have different parent folders. For example:
 
-```SCSS
+```scss
 $govuk-images-path: "/<YOUR-IMAGES-FOLDER>/";
 $govuk-fonts-path: "/<YOUR-FONTS-FOLDER>/";
 ```


### PR DESCRIPTION
The language identifier has to be lowercase for the highlighting to work correctly.