### PR TITLE
Group Sass API Reference by layers, in order

### DIFF
--- a/sassdocs_helpers.rb
+++ b/sassdocs_helpers.rb
@@ -5,12 +5,12 @@ module SassdocsHelpers
     raise "No data in data/sassdocs.json, run `npm install` to generate." unless data.respond_to?(:sassdoc)
 
     # Remove private API entries
-    public_entries = data.sassdoc.select { |doc| doc.access == "public" }
+    public_entries = data.sassdoc.select { |item| item.access == "public" }
     # Remove vendored files, for example SassMQ
-    public_entries = public_entries.reject { |doc| doc.file.path.start_with?("vendor") }
-    # Group the docs by their 'group', for example 'Settings' or 'Helpers'
+    public_entries = public_entries.reject { |item| item.file.path.start_with?("vendor") }
+    # Group the items by their 'group', for example 'Settings' or 'Helpers'
     public_entries
-      .group_by { |doc| doc.group.first }
+      .group_by { |item| item.group.first }
       .group_by { |group_name, _| group_name.split("/").first }
   end
 
@@ -78,12 +78,12 @@ module SassdocsHelpers
     }
   end
 
-  def doc_heading(doc)
+  def item_heading(item)
     # For variables add a dollar to distinguish them from similar mixin/function names
-    if doc.context.type == "variable"
-      "$" + doc.context.name
+    if item.context.type == "variable"
+      "$" + item.context.name
     else
-      doc.context.name
+      item.context.name
     end
   end
 
@@ -107,9 +107,9 @@ module SassdocsHelpers
     end
   end
 
-  def github_url(doc)
+  def github_url(item)
     # Construct GitHub link
-    "https://github.com/alphagov/govuk-frontend/tree/v#{govuk_frontend_version}/src/govuk/#{doc.file.path}#L#{doc.context.line.start}-L#{doc.context.line.end}"
+    "https://github.com/alphagov/govuk-frontend/tree/v#{govuk_frontend_version}/src/govuk/#{item.file.path}#L#{item.context.line.start}-L#{item.context.line.end}"
   end
 
   def govuk_frontend_version

--- a/sassdocs_helpers.rb
+++ b/sassdocs_helpers.rb
@@ -3,6 +3,10 @@ require "json"
 module SassdocsHelpers
   ORDER = %w[settings tools helpers].freeze
 
+  SPECIAL_CASES = {
+    "internet-explorer-8" => "Internet Explorer 8",
+  }.freeze
+
   def format_sassdoc_data(data)
     raise "No data in data/sassdocs.json, run `npm install` to generate." unless data.respond_to?(:sassdoc)
 
@@ -104,7 +108,9 @@ module SassdocsHelpers
     if heading == "undefined"
       "General"
     elsif heading.include?("/")
-      heading.split("/").last.gsub("-", " ").capitalize
+      slug = heading.split("/").last
+
+      SPECIAL_CASES[slug] || slug.gsub("-", " ").capitalize
     else
       "General #{heading}"
     end

--- a/sassdocs_helpers.rb
+++ b/sassdocs_helpers.rb
@@ -1,6 +1,8 @@
 require "json"
 
 module SassdocsHelpers
+  ORDER = %w[settings tools helpers].freeze
+
   def format_sassdoc_data(data)
     raise "No data in data/sassdocs.json, run `npm install` to generate." unless data.respond_to?(:sassdoc)
 
@@ -12,6 +14,7 @@ module SassdocsHelpers
     public_entries
       .group_by { |item| item.group.first }
       .group_by { |group_name, _| group_name.split("/").first }
+      .sort_by { |group| ORDER.index(group.first) || Float::INFINITY }
   end
 
   def mixin_trailing_code(code)

--- a/sassdocs_helpers.rb
+++ b/sassdocs_helpers.rb
@@ -9,7 +9,9 @@ module SassdocsHelpers
     # Remove vendored files, for example SassMQ
     public_entries = public_entries.reject { |doc| doc.file.path.start_with?("vendor") }
     # Group the docs by their 'group', for example 'Settings' or 'Helpers'
-    public_entries.group_by { |doc| doc.group.first }
+    public_entries
+      .group_by { |doc| doc.group.first }
+      .group_by { |group_name, _| group_name.split("/").first }
   end
 
   def mixin_trailing_code(code)
@@ -92,6 +94,16 @@ module SassdocsHelpers
       heading.gsub("/", " / ").titlecase
     else
       "General"
+    end
+  end
+
+  def subgroup_heading(heading)
+    if heading == "undefined"
+      "General"
+    elsif heading.include?("/")
+      heading.split("/").last.gsub("-", " ").capitalize
+    else
+      "General #{heading}"
     end
   end
 

--- a/source/sass-api-reference/index.html.md.erb
+++ b/source/sass-api-reference/index.html.md.erb
@@ -5,19 +5,23 @@ weight: 65
 
 # Sass API reference
 
-<% format_sassdoc_data(data).each do |heading, group| %>
+<% format_sassdoc_data(data).each do |group_name, subgroups| %>
 
-## <%= group_heading(heading) %>
+## <%= group_heading(group_name) %>
 
-<% group.each do |doc| %>
+<% subgroups.each do |subgroup_name, subgroup| %>
 
-### <%= doc_heading(doc) %>
+### <%= subgroup_heading(subgroup_name) %>
+
+<% subgroup.each do |doc| %>
+
+#### <%= doc_heading(doc) %>
 
 <%= doc.description %>
 
 <% if doc.parameter %>
 
-#### Parameters
+##### Parameters
 
 | Name | Description | Type | Default value |
 | ---- | ----------- | ---- | ------------- |
@@ -27,7 +31,7 @@ weight: 65
 <% end %>
 
 <% if doc.deprecated || doc.context.type == 'mixin' %>
-#### Usage
+##### Usage
 
 <% if doc.deprecated %>
     <% partial(:warning_text) do %>
@@ -43,10 +47,9 @@ weight: 65
 <% end %>
 
 <% if doc.example %>
-#### Example<%= "s" if doc.example.length > 1 %>
 
 <% doc.example.each do |example| %>
-##### <%= example.description %>
+##### Example: <%= example.description %>
 
 ```<%= example.type %>
 <%= example.code %>
@@ -60,5 +63,6 @@ weight: 65
 
 <div class="govuk-!-margin-bottom-9"></div>
 
+<% end %>
 <% end %>
 <% end %>

--- a/source/sass-api-reference/index.html.md.erb
+++ b/source/sass-api-reference/index.html.md.erb
@@ -13,42 +13,42 @@ weight: 65
 
 ### <%= subgroup_heading(subgroup_name) %>
 
-<% subgroup.each do |doc| %>
+<% subgroup.each do |item| %>
 
-#### <%= doc_heading(doc) %>
+#### <%= item_heading(item) %>
 
-<%= doc.description %>
+<%= item.description %>
 
-<% if doc.parameter %>
+<% if item.parameter %>
 
 ##### Parameters
 
 | Name | Description | Type | Default value |
 | ---- | ----------- | ---- | ------------- |
-<% parameters_table(doc.parameter).each do |param| %>
+<% parameters_table(item.parameter).each do |param| %>
 |  <%= param.name %> | <%= param.description %> | <%= param.type %> | <%= param.default_value %> |
 <% end %>
 <% end %>
 
-<% if doc.deprecated || doc.context.type == 'mixin' %>
+<% if item.deprecated || item.context.type == 'mixin' %>
 ##### Usage
 
-<% if doc.deprecated %>
+<% if item.deprecated %>
     <% partial(:warning_text) do %>
-        <%= markdown("Deprecated: " +doc.deprecated) %>
+        <%= markdown("Deprecated: " +item.deprecated) %>
     <% end %>
 <% end %>
 
-<% if doc.context.type == 'mixin' %>
+<% if item.context.type == 'mixin' %>
 ```scss
-@include <%= "#{doc.context.name}#{inline_parameters(doc.parameter)}#{mixin_trailing_code(doc.context.code)}" %>
+@include <%= "#{item.context.name}#{inline_parameters(item.parameter)}#{mixin_trailing_code(item.context.code)}" %>
 ```
 <% end %>
 <% end %>
 
-<% if doc.example %>
+<% if item.example %>
 
-<% doc.example.each do |example| %>
+<% item.example.each do |example| %>
 ##### Example: <%= example.description %>
 
 ```<%= example.type %>
@@ -57,8 +57,8 @@ weight: 65
 <% end %>
 <% end %>
 
-<a href="<%= github_url(doc) %>">
-    View source code for <%= doc.file.name %> on GitHub
+<a href="<%= github_url(item) %>">
+    View source code for <%= item.file.name %> on GitHub
 </a>
 
 <div class="govuk-!-margin-bottom-9"></div>

--- a/spec/sassdocs_helpers_spec.rb
+++ b/spec/sassdocs_helpers_spec.rb
@@ -81,34 +81,52 @@ RSpec.describe SassdocsHelpers do
         sassdoc: [
           {
             access: "public",
-            group: %w[mixins],
+            group: %w[helpers/colour],
             file: {
               path: "first.scss",
             },
           },
           {
             access: "public",
-            group: %w[mixins],
+            group: %w[helpers],
             file: {
               path: "second.scss",
             },
           },
           {
             access: "public",
-            group: %w[helpers],
+            group: %w[tools/foo],
             file: {
               path: "third.scss",
+            },
+          },
+          {
+            access: "public",
+            group: %w[helpers/colour],
+            file: {
+              path: "fourth.scss",
             },
           },
         ],
       })
       groups = @helper.format_sassdoc_data(fixture)
-      expect(groups["mixins"].length).to eq(2)
-      expect(groups["mixins"].first.file.path).to eq("first.scss")
-      expect(groups["mixins"].second.file.path).to eq("second.scss")
 
-      expect(groups["helpers"].length).to eq(1)
-      expect(groups["helpers"].first.file.path).to eq("third.scss")
+      expect(groups).to eq({
+        "helpers" => [
+          ["helpers/colour", [
+            fixture.sassdoc[0],
+            fixture.sassdoc[3],
+          ]],
+          ["helpers", [
+            fixture.sassdoc[1],
+          ]],
+        ],
+        "tools" => [
+          ["tools/foo", [
+            fixture.sassdoc[2],
+          ]],
+        ],
+      })
     end
   end
   describe "#mixin_trailing_code" do

--- a/spec/sassdocs_helpers_spec.rb
+++ b/spec/sassdocs_helpers_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe SassdocsHelpers do
       expect(groups.length).to eq(1)
       expect(group_heading).to eq("public")
     end
-    it "groups entries by their group" do
+    it "groups entries sorted into groups" do
       fixture = dothash({
         sassdoc: [
           {
@@ -111,8 +111,13 @@ RSpec.describe SassdocsHelpers do
       })
       groups = @helper.format_sassdoc_data(fixture)
 
-      expect(groups).to eq({
-        "helpers" => [
+      expect(groups).to eq([
+        ["tools", [
+          ["tools/foo", [
+            fixture.sassdoc[2],
+          ]],
+        ]],
+        ["helpers", [
           ["helpers/colour", [
             fixture.sassdoc[0],
             fixture.sassdoc[3],
@@ -120,13 +125,8 @@ RSpec.describe SassdocsHelpers do
           ["helpers", [
             fixture.sassdoc[1],
           ]],
-        ],
-        "tools" => [
-          ["tools/foo", [
-            fixture.sassdoc[2],
-          ]],
-        ],
-      })
+        ]],
+    ])
     end
   end
   describe "#mixin_trailing_code" do

--- a/spec/sassdocs_helpers_spec.rb
+++ b/spec/sassdocs_helpers_spec.rb
@@ -273,7 +273,7 @@ RSpec.describe SassdocsHelpers do
       expect(parameter.first[:default_value]).to eq("<span aria-hidden='true'>—</span>")
     end
   end
-  describe "#doc_heading" do
+  describe "#item_heading" do
     it "returns with a dollar prefix if a variable" do
       fixture = dothash({
         context: {
@@ -281,7 +281,7 @@ RSpec.describe SassdocsHelpers do
           name: "govuk-assets-path",
         },
       })
-      heading = @helper.doc_heading(fixture)
+      heading = @helper.item_heading(fixture)
 
       expect(heading).to eq("$govuk-assets-path")
     end
@@ -292,7 +292,7 @@ RSpec.describe SassdocsHelpers do
           name: "govuk-colour",
         },
       })
-      heading = @helper.doc_heading(fixture)
+      heading = @helper.item_heading(fixture)
 
       expect(heading).to eq("govuk-colour")
     end


### PR DESCRIPTION
At the minute, we list the items in the Sass API Reference by their group, alphabetically:

- Helpers
- Helpers / Colour
- Objects
- Settings / Assets
- Settings / Colours
- Settings / Compatibility
- Settings / Global Styles
- Settings / Ie8
- Settings / Measurements
- Settings / Media Queries
- Settings / Typography
- Tools
- General

Change the structure so that they are listed grouped by the 'layer', in the order settings, tools, then helpers, with each 'group' nested underneath:

- Settings
  - Assets
  - Colours
  - Compatibility
  - Global styles
  - Ie8
  - Measurements
  - Media queries
  - Typography
- Tools
  - General tools
- Helpers
  - General helpers
  - Colour
- Objects
  - General objects
- General
  - General

The eventual plan, once we've updated the Sass documentation in govuk-frontend, is that we'll end up with something like this:

- Settings
  - Assets
  - Colours
  - Compatibility
  - Global styles
  - Internet Explorer 8
  - Measurements
  - Media queries
  - Typography
- Tools
  - General tools
  - Assets
  - Compatibility mode
  - Internet Explorer 8
  - Unit conversion
- Helpers
  - General helpers
  - Accessibility
  - Colour
  - Layout
  - Links
  - Shapes
  - Spacing
  - Typography
- Objects
  - Layout

To avoid going down to H6s(!), the examples are no longer grouped under an 'Example' heading; they are now listed separately, each one starting 'Example: '.

Closes #44 