### PR TITLE
Fix minor IE8 mixin typo

### DIFF
--- a/source/supporting-ie8/index.html.md.erb
+++ b/source/supporting-ie8/index.html.md.erb
@@ -114,7 +114,7 @@ outputted when generating the IE8-specific stylesheet.
   min-width: 100px;
 
   // Specify width for IE8 only
-  @include govuk-is-ie8 {
+  @include govuk-if-ie8 {
     width: 100px;
   }
 }


### PR DESCRIPTION
There is a minor typo. It is using the name of the variable instead of the name of the mixin.