### PR TITLE
Fix linting and run tests on Travis

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,12 @@ inherit_gem:
   rubocop-govuk:
     - config/default.yml
 
+# Exclude `/vendor` because on Travis other gems get installed there
+# Not a problem locally as gems get installed globally outside project 
+AllCops:
+  Exclude:
+    - './vendor/**/*'
+
 Style/HashEachMethods:
   Enabled: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@ language: ruby
 # shipped with Ruby 2.5.
 dist: bionic
 cache: bundler
-script: bundle exec middleman build
+script:
+  - bundle exec middleman build
+  - bundle exec rake
 
 env:
   global:

--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,7 @@ RSpec::Core::RakeTask.new(:spec)
 
 task :lint do
   sh "rubocop"
-  sh "npm run lint --silent"
+  sh "npm run lint"
 end
 
 task default: %w[lint spec]

--- a/config.rb
+++ b/config.rb
@@ -1,12 +1,12 @@
 require "govuk_tech_docs"
 require "sassdocs_helpers"
 
-config[:build_dir] = 'deploy/public'
+config[:build_dir] = "deploy/public"
 
 GovukTechDocs.configure(self)
 
 # Prevent pages from being indexed unless Travis is building the master branch
-config[:tech_docs][:prevent_indexing] = (ENV['TRAVIS_BRANCH'] != 'master')
+config[:tech_docs][:prevent_indexing] = (ENV["TRAVIS_BRANCH"] != "master")
 
 helpers do
   include SassdocsHelpers

--- a/package.json
+++ b/package.json
@@ -5,9 +5,7 @@
   "scripts": {
     "postinstall": "npm run build:sassdoc",
     "build:sassdoc": "sassdoc --parse node_modules/govuk-frontend/govuk/ > data/sassdoc.json",
-    "scripts": {
-      "lint": "standard"
-    }
+    "lint": "standard"
   },
   "devDependencies": {
     "govuk-frontend": "^3.6.0",


### PR DESCRIPTION
This PR:
- Moves linting to scripts so it can be run (Rakefile wasn't able to find the linter with `npm run lint` and the error was suppressed)
- Removes suppressing linting errors when tests are run from Rakefile
- Fixes violations picked up by Rubocop
- Runs tests on Travis
- Excludes the `vendor` folder from Rubocop because on Travis it contains the other gems which can have configs that conflict with `rubocop-govuk` which we use for our code 