### PR TITLE
Update nginx buildpack to v1.1.9

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -7,7 +7,8 @@ applications:
   memory: 64M
   instances: 2
   # https://docs.cloud.service.gov.uk/deploying_apps.html#how-to-use-custom-buildpacks
-  buildpack: https://github.com/cloudfoundry/nginx-buildpack.git#v1.1.9
+  buildpacks:
+    - https://github.com/cloudfoundry/nginx-buildpack.git#v1.1.9
 
   # Send application logs to logit
   # https://docs.cloud.service.gov.uk/monitoring_apps.html#configure-app

--- a/manifest.yml
+++ b/manifest.yml
@@ -7,7 +7,7 @@ applications:
   memory: 64M
   instances: 2
   # https://docs.cloud.service.gov.uk/deploying_apps.html#how-to-use-custom-buildpacks
-  buildpack: https://github.com/cloudfoundry/nginx-buildpack.git#v1.1.7
+  buildpack: https://github.com/cloudfoundry/nginx-buildpack.git#v1.1.9
 
   # Send application logs to logit
   # https://docs.cloud.service.gov.uk/monitoring_apps.html#configure-app


### PR DESCRIPTION
This effectively just updates nginx from v1.17.9 to v1.17.10.

Tested by manually deploying an app to the sandbox space.