### PR TITLE
Update weight of install-using-precompiled-files

### DIFF
--- a/source/install-using-precompiled-files/index.html.md.erb
+++ b/source/install-using-precompiled-files/index.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Install using precompiled files
-weight: 10
+weight: 11
 ---
 
 # Install using precompiled files


### PR DESCRIPTION
'Install using npm' and 'Install using precompiled files' have the same weight of `10`, so the order of their appearance in the nav is random. 

This updates 'Install using precompiled files' to have a weight of `11`, so it sits after 'Install using npm'.