### PR TITLE
Add documentation to configure CSP to work with inline script in page template

### DIFF
--- a/source/importing-css-assets-and-javascript/index.html.md.erb
+++ b/source/importing-css-assets-and-javascript/index.html.md.erb
@@ -193,3 +193,21 @@ For example:
     })
   </script>
 ```
+
+### If your JavaScript isn’t working properly
+
+If your site has a Content Security Policy (CSP), the CSP may block the inline JavaScript in the page template. You may see a warning similar to the following in the developer tools in your browser:
+
+```
+Refused to execute inline script because it violates the following Content Security Policy directive: "default-src 'self'".
+```
+
+You can unblock the JavaScript by including the following hash in your CSP:
+
+```
+sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=
+```
+
+You do not need to make any changes to the HTML.
+
+You can read guidance about [editing CSP files](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) on the MDN website.


### PR DESCRIPTION
This PR documents teams should configure their Content Security Policy to work with the inline script tag in the page template.

The reasoning for this documentation is captured in:
https://github.com/alphagov/govuk-frontend/issues/1811#issuecomment-663171834
https://github.com/alphagov/govuk-frontend-docs/issues/68

We also have a [related PR](https://github.com/alphagov/govuk-frontend/pull/1884) to test if hash in these docs matches the inline script tag in page template. 

Fixes https://github.com/alphagov/govuk-frontend-docs/issues/68

Thanks @m-green for helping to write this up 🙏 