### PR TITLE
Fix style in JavaScript heading

### DIFF
--- a/source/importing-css-assets-and-javascript/index.html.md.erb
+++ b/source/importing-css-assets-and-javascript/index.html.md.erb
@@ -194,7 +194,7 @@ For example:
   </script>
 ```
 
-### If your JavaScript isn’t working properly
+### If your JavaScript is not working properly
 
 If your site has a Content Security Policy (CSP), the CSP may block the inline JavaScript in the page template. You may see a warning similar to the following in the developer tools in your browser:
 


### PR DESCRIPTION
Fix style in heading from 'don't' to GOV.UK style 'do not'.