### PR TITLE
Add docs on testing with HTML fixtures

### DIFF
--- a/source/testing-your-html/index.html.md.erb
+++ b/source/testing-your-html/index.html.md.erb
@@ -1,14 +1,14 @@
 ---
-title: Test your HTML matches GOV.UK Frontend
+title: Test if your HTML matches GOV.UK Frontend
 weight: 61
 ---
 
-# Test your HTML matches GOV.UK Frontend
+# Test if your HTML matches GOV.UK Frontend
 
 You can use our test fixtures to check you're outputting the same HTML that GOV.UK Frontend uses, when you:
 
 - create your own component macros (also called ‘partials’ or ‘templates’)
-- update GOV.UK Frontend
+- [update GOV.UK Frontend](/updating-with-npm/)
 
 ## Using the HTML test files
 

--- a/source/testing-your-html/index.html.md.erb
+++ b/source/testing-your-html/index.html.md.erb
@@ -1,0 +1,51 @@
+---
+title: Test your HTML matches GOV.UK Frontend
+weight: 61
+---
+
+# Test your HTML matches GOV.UK Frontend
+
+You can use our test fixtures to check you're outputting the same HTML that GOV.UK Frontend uses, when you:
+
+- create your own component macros (also called ‘partials’ or ‘templates’)
+- update GOV.UK Frontend
+
+## Using the HTML test files
+
+If you [installed GOV.UK Frontend with Node.js package manager (npm)](/installing-with-npm), you can find the `fixtures.json` file for each component in the `node_modules/govuk-frontend/govuk/components/COMPONENT-NAME/` folder, where `COMPONENT-NAME` is the name of the component.
+
+For example, you can find the `fixtures.json` file for the button component in the `node_modules/govuk-frontend/govuk/components/button/` folder:
+
+```js
+{
+  "component": "button",
+  "fixtures": [
+    {
+      "name": "default",
+      "options": {
+        "text": "Save and continue"
+      },
+      "html": "<button class=\"govuk-button\" data-module=\"govuk-button\">\n  Save and continue\n</button>"
+    },
+    {
+      "name": "secondary button",
+      "options": {
+        "text": "Find address",
+        "classes": "govuk-button--secondary"
+      },
+      "html": "<button class=\"govuk-button govuk-button--secondary\" data-module=\"govuk-button\">\nFind address\n</button>"
+    },
+    ...
+  ]
+}
+```
+
+Each object in the `fixtures` list is a different example of the component, where:
+
+- `name` is the name of the example
+- `options` are the options that generate this example's `html`
+- `html` is the HTML that GOV.UK Frontend outputs with these options
+
+For each example, pass `options` into your own macro and check the generated HTML matches `html`.
+
+If your HTML does not match exactly, you'll need to write your tests so they ignore known differences. For example your framework may add extra whitespace or attributes to your HTML.


### PR DESCRIPTION
Part of https://github.com/alphagov/govuk-frontend/issues/1830

This adds a new docs page about testing your HTML matches GOV.UK Frontend. 

Before merging we need to:

- [x] get the content pre-i'd and 2i'd
- [x] update the code example with the final code