### PR TITLE
Temporary fix for CloudFoundry deployment issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_deploy:
   - wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo apt-key add -
   - echo "deb https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
   - sudo apt-get update
-  - sudo apt-get install -y cf-cli
+  - sudo apt-get install -y cf-cli --allow-unauthenticated
 
 before_script:
   - npm install


### PR DESCRIPTION
Our deployments are currently failing due to a GPG error. This is a known issue that CF are currently working on.

This temporary fix will be removed as soon as CF have issued a fix for this.