### PR TITLE
Remove temp fix for CloudFoundry issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_deploy:
   - wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo apt-key add -
   - echo "deb https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
   - sudo apt-get update
-  - sudo apt-get install -y cf-cli --allow-unauthenticated
+  - sudo apt-get install -y cf-cli
 
 before_script:
   - npm install


### PR DESCRIPTION
Removes the fix introduced in https://github.com/alphagov/govuk-frontend-docs/pull/78 as it looks like CloudFoundry have fixed the underlying issue.