### PR TITLE
Fix broken numbering in 'Get started' content

### DIFF
--- a/source/get-started/index.html.md.erb
+++ b/source/get-started/index.html.md.erb
@@ -55,9 +55,8 @@ There are also different ways you can [import GOV.UK Frontend's CSS](/importing-
 Your component will not use the right font or images until you've added GOV.UK Frontend's assets to your application.
 
 1. Copy the following 2 folders:
-
-- `/node_modules/govuk-frontend/govuk/assets/images` folder to `<YOUR-APP>/assets/images`
-- `/node_modules/govuk-frontend/govuk/assets/fonts` folder to `<YOUR-APP>/assets/fonts`
+  - `/node_modules/govuk-frontend/govuk/assets/images` folder to `<YOUR-APP>/assets/images`
+  - `/node_modules/govuk-frontend/govuk/assets/fonts` folder to `<YOUR-APP>/assets/fonts`
 
 2. Run your application, then use [the Fonts tab in Firefox Page Inspector](https://developer.mozilla.org/en-US/docs/Tools/Page_Inspector/How_to/Edit_fonts#The_Fonts_tab) to check the accordion is using the GDS Transport font.
 


### PR DESCRIPTION
[Get started > Get the font and images working](https://frontend.design-system.service.gov.uk/get-started/#4-get-the-font-and-images-working).

In the current content, the number 1 is repeated after a bullet list.
