### PR TITLE
Use PaaS-supplied nginx buildpack

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -6,9 +6,8 @@ applications:
   health-check-http-endpoint: /canary.html
   memory: 64M
   instances: 2
-  # https://docs.cloud.service.gov.uk/deploying_apps.html#how-to-use-custom-buildpacks
   buildpacks:
-    - https://github.com/cloudfoundry/nginx-buildpack.git#v1.1.9
+    - nginx_buildpack
 
   # Send application logs to logit
   # https://docs.cloud.service.gov.uk/monitoring_apps.html#configure-app


### PR DESCRIPTION
When we set these docs up, PaaS did not support the nginx buildpack, so we had to reference the buildpack using its GitHub URL, pinning to a specific version.

PaaS now provide an nginx buildpack, so use that instead. This means whenever PaaS update their buildpacks we'll automatically use the latest version when we next deploy.

The current version of the buildpack is 1.1.18, so this effectively bumps the buildpack version from 1.1.9 to 1.1.18, and the nginx version from v1.17.10 to v1.19.4 (verified by deploying a test app to the sandbox).

Closes #94 