### PR TITLE
Add contextual info to IE8 doc

### DIFF
--- a/source/supporting-ie8/index.html.md.erb
+++ b/source/supporting-ie8/index.html.md.erb
@@ -5,9 +5,10 @@ weight: 50
 
 # Support Internet Explorer 8
 
-If you are including GOV.UK Frontend as part of your application's stylesheets
-then you will need to do some additional work to support Internet Explorer 8
-(IE8).
+You will need to do some extra work to support Internet Explorer 8 (IE8) if:
+
+- your users' browser is IE8
+- you include GOV.UK Frontend in your application’s stylesheets
 
 1. Include an HTML5 shiv.
 2. Generate an IE8-specific stylesheet.

--- a/source/supporting-ie8/index.html.md.erb
+++ b/source/supporting-ie8/index.html.md.erb
@@ -5,10 +5,7 @@ weight: 50
 
 # Support Internet Explorer 8
 
-You will need to do some extra work to support Internet Explorer 8 (IE8) if:
-
-- your users' browser is IE8
-- you include GOV.UK Frontend in your application’s stylesheets
+Follow these extra steps if your service needs to support Internet Explorer 8 (IE8):
 
 1. Include an HTML5 shiv.
 2. Generate an IE8-specific stylesheet.


### PR DESCRIPTION
The [current IE8 content](https://frontend.design-system.service.gov.uk/supporting-ie8/#support-internet-explorer-8) doesn't specify that you only follow these steps if you've already decided to support IE8. We should call this out.