### PR TITLE
Remove unnecessary text from migration doc

### DIFF
--- a/source/migrating-from-legacy-products/index.html.md.erb
+++ b/source/migrating-from-legacy-products/index.html.md.erb
@@ -29,10 +29,10 @@ You can use your list to see where you can replace similar elements in your serv
 
 We recommend using [a template engine like Nunjucks](https://mozilla.github.io/nunjucks/) to abstract each component into a reusable macro (also called a 'partial' or 'template'). You can do this before or during your migration.
 
-If you use macros, your project will be:
+Macros will help make your project easier to:
 
-- easier to migrate, because your project will be organised the same way we organise the GOV.UK Design System
-- easier to update when new versions of GOV.UK Frontend are released
+- migrate, because your project will be organised the same way we organise the GOV.UK Design System
+- update when new versions of GOV.UK Frontend are released
 
 If you're using Node.js, you can [use our Nunjucks macros](/use-nunjucks/).
 


### PR DESCRIPTION
Current content unnecessarily repeats "easier to."