### PR TITLE
Update tables to meet WCAG v2.1 AA

### DIFF
--- a/source/migrating-from-legacy-products/index.html.md.erb
+++ b/source/migrating-from-legacy-products/index.html.md.erb
@@ -116,11 +116,11 @@ Replace the following old colour variables if you're using Sass.
 
 Old colour|Suggested replacement
 | --- | --- |
-`bright-red`|`red`
-`grey-1`|`dark-grey`
-`grey-2`|`mid-grey`
-`grey-3`|`light-grey`
-`grey-4`|`light-grey`
+# `bright-red`|`red`
+# `grey-1`|`dark-grey`
+# `grey-2`|`mid-grey`
+# `grey-3`|`light-grey`
+# `grey-4`|`light-grey`
 
 You should also remove any temporary overrides you added earlier.
 

--- a/source/sass-api-reference/index.html.md.erb
+++ b/source/sass-api-reference/index.html.md.erb
@@ -26,7 +26,7 @@ weight: 65
 | Name | Description | Type | Default value |
 | ---- | ----------- | ---- | ------------- |
 <% parameters_table(item.parameter).each do |param| %>
-|  <%= param.name %> | <%= param.description %> | <%= param.type %> | <%= param.default_value %> |
+| # <%= param.name %> | <%= param.description %> | <%= param.type %> | <%= param.default_value %> |
 <% end %>
 <% end %>
 


### PR DESCRIPTION
Fixes #104 (Fix accessibility issues by updating the govuk_tech_docs gem to 2.2.0 [before 31 March])

## Why is the change necessary?

We have to update our Tech Docs Gem to incorporate several accessibility fixes in the technical documentation template. Our [accessibility statement](https://design-system.service.gov.uk/accessibility/) (at time of writing this) references these issues. For example, as here, accessibility of tables.

According to [WCAG 2.1 success criterion 1.3.1 (Info and Relationships)](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html), 'identifying' (or marking up) headers is a good way of telling assistive tech users which row and which column, together, identify a particular cell.

However, in some of our Frontend tables (see [Remove our old frameworks](https://frontend.design-system.service.gov.uk/migrating-from-legacy-products/#remove-our-old-frameworks) and [Sass API reference | Tools](https://frontend.design-system.service.gov.uk/sass-api-reference/#tools)), the column row headers are not marked up. This can make tables hard to read for users of assistive tech, particularly when tables contain more than 2 columns and users have to read 'down' and then 'across' to locate some information.

## How does this PR address the issue?

The change in this PR improves accessibility of tables in line with [WCAG 2.1 success criterion 1.3.1 (Info and Relationships)](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html).

In each table row, we're adding `# ` (hash and a space) before the content inside the first cell. The space after the hash is not required - as the fix will work without it - but we felt that it made the markdown easier to read.

The technical writer leading on accessibility fixes (in the wider org) said that tables like the one in [Remove our old frameworks](https://frontend.design-system.service.gov.uk/migrating-from-legacy-products/#remove-our-old-frameworks) may not need markup. This is because that table has only 2 columns and its purpose (how to replace colours) is clear.

However, we decided to be cautious and include markup in the table anyway. We feel that if the table contains markup, then this makes it likelier that users will be able to interpret the table correctly.

## Consequences

- Text in the first column's cells displays in bold (see second screenshot below)
- When users come to these tables, their assistive tech will be able to determine which row and which column are associated with the content in each cell

### How a table currently displays in Design System:
![image](https://user-images.githubusercontent.com/72507742/111657765-a76ab600-8803-11eb-98aa-8a11c9ac107e.png)

### How a table will display after these changes: 
![image](https://user-images.githubusercontent.com/72507742/111657864-bfdad080-8803-11eb-8325-2c4c01804397.png)