### PR TITLE
Update Tech Docs Gem to fix accessibility issues

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,7 +45,7 @@ GEM
     fast_blank (1.0.0)
     fastimage (2.2.3)
     ffi (1.15.0)
-    govuk_tech_docs (2.2.1)
+    govuk_tech_docs (2.2.2)
       chronic (~> 0.10.2)
       middleman (~> 4.0)
       middleman-autoprefixer (~> 2.10.0)
@@ -68,7 +68,7 @@ GEM
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
     json (2.5.1)
-    kramdown (2.3.0)
+    kramdown (2.3.1)
       rexml
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)


### PR DESCRIPTION
Fixes [#108](https://github.com/alphagov/govuk-frontend-docs/issues/108) (Fix accessibility issues by updating the govuk_tech_docs gem to 2.2.2 [before 31 March]).

Two days ago (24 March 2021), we [updated our Tech Docs Gem to incorporate several accessibility fixes in the Technical Documentation Template](https://github.com/alphagov/govuk-frontend-docs/issues/104).

Since then, we have learned that a new version of the Template has been released to fix some outstanding issues with the previous version. For example, users being able, when they use the search field, to focus elements that are 'hidden' behind other content.

This PR will update our Tech Docs Gem to the latest version of the Template. We can then test whether users can focus elements that should remain hidden to them. Point 5 of the [accessibility-fixes guidance](https://docs.google.com/document/d/1QlTbEV6xyUsc5Tb94Iw5GrnifCuzaZB8TDIKmV5QDCs/edit#heading=h.r8c1hz882gha) describes how to test for this behaviour.