### PR TITLE
Replace instances of master with main

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,4 +39,4 @@ deploy:
   # deployed!
   skip_cleanup: true
   on:
-    branch: master
+    branch: main

--- a/config.rb
+++ b/config.rb
@@ -5,8 +5,8 @@ config[:build_dir] = "deploy/public"
 
 GovukTechDocs.configure(self)
 
-# Prevent pages from being indexed unless Travis is building the master branch
-config[:tech_docs][:prevent_indexing] = (ENV["TRAVIS_BRANCH"] != "master")
+# Prevent pages from being indexed unless Travis is building the main branch
+config[:tech_docs][:prevent_indexing] = (ENV["TRAVIS_BRANCH"] != "main")
 
 helpers do
   include SassdocsHelpers


### PR DESCRIPTION
Part of https://github.com/alphagov/govuk-frontend-docs/issues/100

## What
Replace instances of "master" with "main" in preparation for the default branch renaming work

## Why
Many communities on GitHub are considering renaming the default branch name of their repository from master, as this terminology can be offensive. Statements and guidance have been published by Git [here](https://sfconservancy.org/news/2020/jun/23/gitbranchname/) and GitHub [here](https://github.com/github/renaming).

New GitHub repositories use `main` as the name for the default branch, so it makes sense that we should follow this convention, as well as matching what other teams within GDS are doing so we are consistent.
