### PR TITLE
Update GOVUK Frontend to 3.12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3539,9 +3539,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.10.1.tgz",
-      "integrity": "sha512-2x6B0jV1pTx4Alxm3MY222BfIQpg+ctUYaUzyBjmNkisWKdRmCP61oyFXklZgqXMjvaN+oo3rRbAALrxFTeeig==",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.12.0.tgz",
+      "integrity": "sha512-+mM8BqEUqsBVSV/ud0dEhE8OmMdhkK53eEUp5YyPN+y3mwcdRnwwP2A2B5qFdFi6E6j/2AYuCG8l5kXD+JXNxA==",
       "dev": true
     },
     "graceful-fs": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "check-links": "hyperlink -ri deploy/public/index.html --skip 'property=\"og:url\"' | tap-spot"
   },
   "devDependencies": {
-    "govuk-frontend": "^3.10.1",
+    "govuk-frontend": "^3.12.0",
     "hyperlink": "^4.5.0",
     "sassdoc": "^2.7.1",
     "standard": "^14.3.3",


### PR DESCRIPTION
Closes https://github.com/alphagov/govuk-frontend-docs/issues/120

Note that this release of GOVUK Frontend includes changes to the link styles, but these changes are opt-in.
We are not opting-in to these changes in this PR, but we want the Sass API docs to be updated