### PR TITLE
Tweak reference to CSP

### DIFF
--- a/source/importing-css-assets-and-javascript/index.html.md.erb
+++ b/source/importing-css-assets-and-javascript/index.html.md.erb
@@ -210,4 +210,4 @@ sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=
 
 You do not need to make any changes to the HTML.
 
-You can read guidance about [editing CSP files](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) on the MDN website.
+[Learn more about Content Security Policy on the MDN website](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP).


### PR DESCRIPTION
Content Security Policy is defined using headers or meta tags rather than files. As it's not defined in a file you can edit, 'editing CSP files' doesn't really make sense here. The page we're linking to is a pretty general broad guide on CSP, that touches on a lot more than just how to edit it, so just refer to it as general guidance on CSP.

Also make the destination (the MDN website) part of the link text, so that someone navigating out of context still understands that it takes them to an external page.