### PR TITLE
Update JS docs to say users can use nonce in CSP

### DIFF
--- a/source/importing-css-assets-and-javascript/index.html.md.erb
+++ b/source/importing-css-assets-and-javascript/index.html.md.erb
@@ -18,7 +18,7 @@ To import all the Sass rules from GOV.UK Frontend, add the following to your Sas
 ### Import specific parts of the CSS
 
 If you want to improve how quickly your service's pages load in browsers, you can import only the Sass rules you need.
- 
+
 1. Import `node_modules/govuk-frontend/govuk/base` in your Sass file.
 2. Import the parts of the CSS you need.
 
@@ -35,7 +35,7 @@ For example, add the following to your Sass file to import the CSS you need for 
 @import "node_modules/govuk-frontend/govuk/utilities/all";
 @import "node_modules/govuk-frontend/govuk/overrides/all";
 ```
-You can remove lines that import parts of the CSS you do not need. 
+You can remove lines that import parts of the CSS you do not need.
 
 [Read more about the different parts of GOV.UK Frontend’s CSS](https://github.com/alphagov/govuk-frontend/tree/master/src/govuk).
 
@@ -196,13 +196,22 @@ For example:
 
 ### If your JavaScript is not working properly
 
-If your site has a Content Security Policy (CSP), the CSP may block the inline JavaScript in the page template. You may see a warning similar to the following in the developer tools in your browser:
+If your site has a Content Security Policy (CSP), the CSP may block the inline JavaScript in the page template. You may see a warning like the following in your browser's developer tools:
 
 ```
 Refused to execute inline script because it violates the following Content Security Policy directive: "default-src 'self'".
 ```
 
-You can unblock the JavaScript by including the following hash in your CSP:
+To unblock inline JavaScript, do one of the following:
+
+- include a hash (recommended)
+- use a nonce
+
+Make sure you [understand the security implications of using either option](https://www.w3.org/TR/CSP/#security-considerations), as wrong implementation could affect your service’s security. If you're not sure what to do, talk to a security expert.
+
+#### Use a hash to unblock inline JavaScript
+
+You can unblock inline JavaScript by including the following hash in your CSP:
 
 ```
 sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=
@@ -210,4 +219,20 @@ sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=
 
 You do not need to make any changes to the HTML.
 
-[Learn more about Content Security Policy on the MDN website](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP).
+[Learn more about Content Security Policy on the MDN Web Docs website](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP).
+
+#### Use a `nonce` attribute to unblock inline JavaScript
+
+If you're unable to use the hash in your CSP, you can also use a `nonce` on inline JavaScript.
+
+However, you should provide a nonce that hostile actors cannot guess. Otherwise, they could easily find a way around your CSP.
+
+You should use a value which is:
+
+- unique for each HTTP response
+- generated using a cryptographically-secure random generator
+- at least 32 characters for hex, or 24 characters for base64
+
+Make sure your script tags do not have any untrusted or unescaped variables.
+
+If you're using the Nunjucks page template, you can add the `nonce` attribute by setting the `cspNonce` variable.


### PR DESCRIPTION
Fixes [#130](https://github.com/alphagov/govuk-frontend-docs/issues/130).

## What this change does
This PR adds content to the [JavaScript subsection of our Frontend docs](https://frontend.design-system.service.gov.uk/importing-css-assets-and-javascript/#select-and-initialise-part-of-a-page).

## Why we made this change
We need to tell users ([see #2246 for original issue](https://github.com/alphagov/govuk-frontend/issues/2246)) they can add a nonce to the `js-enabled` inline script in the template. This addition allows the script to execute under a CSP (Content Security Policy).

While we recommend that users include a hash in their CSP, we've [had feedback](https://github.com/alphagov/govuk-frontend/issues/2246) that this could lead, in some circumstances, to the breaking of JavaScript components. For example: if (in the future) users update GOV.UK Frontend after there's been a hash update they're unaware of. So, we need to give users an alternative, to help them avoid this risk.

At the same time, we need to emphasise that users should make their nonces hard to guess - because otherwise [hostile actors could easily bypass their CSP](http://sebastian-lekies.de/csp/bypasses.php).