### PR TITLE
Update govuk-frontend to version 3.13.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3566,9 +3566,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.12.0.tgz",
-      "integrity": "sha512-+mM8BqEUqsBVSV/ud0dEhE8OmMdhkK53eEUp5YyPN+y3mwcdRnwwP2A2B5qFdFi6E6j/2AYuCG8l5kXD+JXNxA==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.13.0.tgz",
+      "integrity": "sha512-JiPCeasuHZ+9m1VyqhsfE81PhWIW4Sweoe6Jvn6oMjQNr75ZpupiytN3DGwA+WKOoESHZibIG+heAzlkdZ/MhA==",
       "dev": true
     },
     "graceful-fs": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "check-links": "hyperlink -ri deploy/public/index.html --skip 'property=\"og:url\"' | tap-spot"
   },
   "devDependencies": {
-    "govuk-frontend": "^3.12.0",
+    "govuk-frontend": "^3.13.0",
     "hyperlink": "^4.5.0",
     "sassdoc": "^2.7.1",
     "standard": "^14.3.3",


### PR DESCRIPTION
Closes https://github.com/alphagov/govuk-frontend-docs/issues/132

Updates govuk-frontend to version 3.13.0