### PR TITLE
Update quotes in code example

### DIFF
--- a/source/updating-with-npm/index.html.md.erb
+++ b/source/updating-with-npm/index.html.md.erb
@@ -20,7 +20,7 @@ If you do not have command line access, you can see the version number in the
 `package.json` file in the root of your project directory. For example:
 
 ```json
-'govuk-frontend': ‘2.11.0’
+"govuk-frontend": "2.11.0"
 ```
 
 ## Update GOV.UK Frontend using npm


### PR DESCRIPTION
The example of what the dependency might look like in a user's `package.json` uses a mix of single and typographic quotes.

Only double quotes are supported in JSON, so update the example to use them instead.