### PR TITLE
Add info about Sass deprecations to install guide

### DIFF
--- a/source/installing-with-npm/index.html.md.erb
+++ b/source/installing-with-npm/index.html.md.erb
@@ -19,6 +19,8 @@ weight: 10
 
 3. Install [Dart Sass](https://www.npmjs.com/package/sass) - version 1.0.0 or higher.
 
+    If you're using Dart Sass 1.33.0 or greater, you may see deprecation warnings when compiling your Sass. You can [silence deprecation warnings caused by dependencies](/importing-css-assets-and-javascript/#silence-deprecation-warnings-from-dependencies-in-dart-sass) if required.
+
     We recommend you do not use either LibSass or Ruby Sass, as they are deprecated.
 
     Currently, GOV.UK Frontend supports:


### PR DESCRIPTION
Fixes [#153](https://github.com/alphagov/govuk-frontend-docs/issues/153).

This PR adds content to the [npm installation requirements](https://frontend.design-system.service.gov.uk/installing-with-npm/#install-with-node-js-package-manager-npm).

We're asking users not to use either LibSass or Ruby Sass, as we may stop supporting these implementations in future.

