### PR TITLE
Amend duplicated folder structure text

### DIFF
--- a/source/importing-css-assets-and-javascript/index.html.md.erb
+++ b/source/importing-css-assets-and-javascript/index.html.md.erb
@@ -101,7 +101,7 @@ You should use an automated task or your build pipeline to copy the files, so yo
 
 #### If you have your own folder structure
 
-If you use a different folder structure than `<YOUR-APP>/assets/images` and `<YOUR-APP>/assets/images`, you can set Sass variables so that Sass builds the CSS to point to your folders.
+If you use a different folder structure than `<YOUR-APP>/assets/images` and `<YOUR-APP>/assets/fonts`, you can set Sass variables so that Sass builds the CSS to point to your folders.
 
 Set one of the following before the `@import` line in your Sass file:
 


### PR DESCRIPTION
Fixes https://github.com/alphagov/govuk-frontend-docs/issues/156

`<YOUR-APP>/assets/images` was repeated twice. Looking at the text above, it
seems like this should be `<YOUR-APP>/assets/images` and `<YOUR-APP>/assets/fonts`