### PR TITLE
Fix deploys

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
             name: build
-            path: deploy/**
+            path: deploy/
             retention-days: 1
 
   # Deploy Frontend Docs to production when the main branch is changed


### PR DESCRIPTION
Deploys were failing because the manifest was expecting the app to be in the deploy folder, but the upload-artifact step was archiving only the contents of the deploy folder. This commit should fix that by changing the arguments to upload-artifact to remove the wildcard; apparently the wildcard acts to remove path elements [[1]].

Note: I'm not confident this will fix it, but there's only one way to find out! :sweat_smile:

[1]: https://github.com/actions/upload-artifact#upload-using-multiple-paths-and-exclusions