### PR TITLE
Fix deploys, take #2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,7 +76,6 @@ jobs:
               core.error('Code to deploy does not match code in main branch')
               core.setFailed('Refusing to deploy, please do not re-run this workflow run')
             }
-      - uses: actions/checkout@v2
 
       - name: Download build artifact
         uses: actions/download-artifact@v2

--- a/deploy/manifest.yml
+++ b/deploy/manifest.yml
@@ -1,7 +1,6 @@
 ---
 applications:
 - name: govuk-frontend-docs
-  path: ./deploy
   health-check-type: http
   health-check-http-endpoint: /canary.html
   memory: 64M


### PR DESCRIPTION
Commit f731fa1 tried to fix broken deploys by preserving the top level directory name of the deploy folder. This didn't work, files are still being archived as `public/whatever` instead of `deploy/public/whatever`. This commit tries a different tack and just moves the manifest into the deploy folder, and then ensures that only the deploy folder is present on the machine that does the deploy. This means that we don't need to worry about pushing things to PaaS that we don't want to deploy (in theory).