### PR TITLE
Remove beta tag

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -6,7 +6,6 @@ show_govuk_logo: true
 service_name: Frontend
 full_service_name: GOV.UK Frontend
 service_link: /
-phase: Beta
 
 # Links to show on right-hand-side of header
 header_links:


### PR DESCRIPTION
The GOV.UK Design System, which includes GOV.UK Frontend, [passed its live assessment on 16 November 2021][1].

Remove the beta tag from the header, as this is now a live service.

[1]: https://www.gov.uk/service-standard-reports/gov-uk-design-system-live-reassessment