### PR TITLE
Add documentation for importing GOV.UK Frontend ES modules

### DIFF
--- a/source/importing-css-assets-and-javascript/index.html.md.erb
+++ b/source/importing-css-assets-and-javascript/index.html.md.erb
@@ -169,16 +169,18 @@ Then import the JavaScript file before the closing `</body>` tag of your HTML pa
 If you decide to import using a bundler, we recommend you use `import` to only import the JavaScript for components you're using in your service. For example:
 
 ```javascript
-import { SkipLink, Header } from 'govuk-frontend'
+import { SkipLink, Radios } from 'govuk-frontend'
 
 var $skipLink = document.querySelector('[data-module="govuk-skip-link"]')
 if ($skipLink) {
   new SkipLink($skipLink).init()
 }
 
-var $header = document.querySelector('[data-module="govuk-header"]')
-if ($header) {
-  new Header($header).init()
+var $radios = document.querySelectorAll('[data-module="govuk-radios]')
+if ($radios) {
+  for (var i = 0; i < $radios.length; i++) {
+    new Radios($radios[i]).init()
+  }
 }
 ```
 

--- a/source/importing-css-assets-and-javascript/index.html.md.erb
+++ b/source/importing-css-assets-and-javascript/index.html.md.erb
@@ -164,6 +164,20 @@ Then import the JavaScript file before the closing `</body>` tag of your HTML pa
 </body>
 ```
 
+#### Select and initialise an individual component
+
+You can select and initialise a specific component by using its `data-module` attribute. For example, use `govuk-radios` to initialise the first radio component on a page:
+
+```html
+  <script>
+    var Radios = window.GOVUKFrontend.Radios
+    var $radio = document.querySelector('[data-module="govuk-radios"]')
+    if ($radio) {
+      new Radios($radio).init()
+    }
+  </script>
+```
+
 ### Import JavaScript using a bundler
 
 If you decide to import using a bundler, we recommend you use `import` to only import the JavaScript for components you're using in your service. For example:
@@ -215,20 +229,6 @@ If you're using a bundler that uses CommonJS like [Browserify](http://browserify
 ```javascript
 const GOVUKFrontend = require('govuk-frontend')
 GOVUKFrontend.initAll()
-```
-
-### Select and initialise an individual component
-
-You can select and initialise a specific component by using its `data-module` attribute. For example, initialise the first radio component on a page using `govuk-radios`:
-
-```html
-  <script>
-    var Radios = window.GOVUKFrontend.Radios
-    var $radio = document.querySelector('[data-module="govuk-radios"]')
-    if ($radio) {
-      new Radios($radio).init()
-    }
-  </script>
 ```
 
 ### Select and initialise part of a page

--- a/source/importing-css-assets-and-javascript/index.html.md.erb
+++ b/source/importing-css-assets-and-javascript/index.html.md.erb
@@ -166,7 +166,23 @@ Then import the JavaScript file before the closing `</body>` tag of your HTML pa
 
 ### Import JavaScript using a bundler
 
-If you decide to import using a bundler, use `import` to import all of GOV.UK Frontend's components, then run the `initAll` function to initialise them:
+If you decide to import using a bundler, we recommend you use `import` to only import the JavaScript for components you're using in your service. For example:
+
+```javascript
+import { SkipLink, Header } from 'govuk-frontend'
+
+var $skipLink = document.querySelector('[data-module="govuk-skip-link"]')
+if ($skipLink) {
+  new SkipLink($skipLink).init()
+}
+
+var $header = document.querySelector('[data-module="govuk-header"]')
+if ($header) {
+  new Header($header).init()
+}
+```
+
+If you need to import all of GOV.UK Frontend's components, then run the `initAll` function to initialise them:
 
 ```javascript
 import { initAll } from 'govuk-frontend'

--- a/source/importing-css-assets-and-javascript/index.html.md.erb
+++ b/source/importing-css-assets-and-javascript/index.html.md.erb
@@ -191,6 +191,25 @@ import { initAll } from 'govuk-frontend'
 initAll()
 ```
 
+If you're using Webpack, you may need to add the following to your Webpack config file:
+
+```json
+resolve: {
+  extensions: ['.mjs'],
+},
+module: {
+  rules: [
+    {
+      test: /\.mjs$/,
+      type: 'javascript/auto',
+      resolve: {
+        fullySpecified: false
+      }
+    }
+  ]
+}
+```
+
 If you're using a bundler that uses CommonJS like [Browserify](http://browserify.org/), you should use `require`:
 
 ```javascript

--- a/source/importing-css-assets-and-javascript/index.html.md.erb
+++ b/source/importing-css-assets-and-javascript/index.html.md.erb
@@ -191,7 +191,7 @@ import { initAll } from 'govuk-frontend'
 initAll()
 ```
 
-If you're using Webpack, you may need to add the following to your Webpack config file:
+If you're using Webpack, you may need to add some or all of the following to your Webpack config file:
 
 ```json
 resolve: {


### PR DESCRIPTION
## What
Adds documentation for how to install GOV.UK Frontend ES modules (new functionality, added in https://github.com/alphagov/govuk-frontend/pull/2586) 

## Why
We need to tell people how to use the new ES modules if they want to. We should also use this is an opportunity to recommend people only install the component JavaScript that their application actually needs, as it has a performance benefit in comparison to loading everything regardless of whether it's being used or not.

**Note: this should only be merged once https://github.com/alphagov/govuk-frontend/pull/2586 has been released in a new version of GOV.UK Frontend**