### PR TITLE
Make example heading colons conditional on a description being present

### DIFF
--- a/source/sass-api-reference/index.html.md.erb
+++ b/source/sass-api-reference/index.html.md.erb
@@ -56,7 +56,7 @@ $<%= item.context.name %>: <%= item.context.value %>;
 <% if item.example %>
 
 <% item.example.each do |example| %>
-##### Example: <%= example.description %>
+##### Example<% if example.description %>: <%= example.description %><% end %>
 
 ```<%= example.type %>
 <%= example.code %>


### PR DESCRIPTION
Adds an `if` statement around the colon and description of "example" headings in the Sass API reference, so these only get rendered if a description exists. 

Resolves #117. 