### PR TITLE
Add troubleshooting for M1 Macs during bundle install

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,17 @@ Run `bundle update` to make sure you're using the most recent Ruby gem versions.
 
 Run `bundle exec middleman build --verbose` to get detailed error messages to help with finding the problem.
 
+### OpenSSL issues on newer versions of MacOS
+Because of some quirks with OpenSSL on newer versions of MacOS, you might run into an error with `eventmachine` while running `bundle install`.
+
+To fix this, run:
+
+```
+brew install openssl
+bundle config build.eventmachine --with-cppflags=-I$(brew --prefix openssl)/include
+bundle install
+```
+
 ## Testing
 
 To run the linter and Ruby tests, run `bundle exec rake`.


### PR DESCRIPTION
During `bundle install` on M1 machines, there appears to be an issue with `eventmachine-1.2.7`, which complains with the error:

```
fatal error: 'openssl/ssl.h' file not found
#include <openssl/ssl.h>
         ^~~~~~~~~~~~~~~
1 error generated.
```

We've managed to get past this by running `brew install openssl` and following the directions here: https://stackoverflow.com/questions/30818391/gem-eventmachine-fatal-error-openssl-ssl-h-file-not-found/31516586#31516586

This adds these instructions to the troubleshooting section of the README.