### PR TITLE
Suggest Dart Sass 1.49.10 for silencing warnings

### DIFF
--- a/source/importing-css-assets-and-javascript/index.html.md.erb
+++ b/source/importing-css-assets-and-javascript/index.html.md.erb
@@ -80,7 +80,7 @@ If you're using Dart Sass 1.33.0 or greater, you may see deprecation warnings wh
 DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.
 ```
 
-We're currently unable to fix these deprecation warnings without breaking support for LibSass. However, you can silence the warnings caused by GOV.UK Frontend and other dependencies. Make sure you're using Dart Sass 1.35.0 or greater, and then if you're:
+We're currently unable to fix these deprecation warnings without breaking support for LibSass. However, you can silence the warnings caused by GOV.UK Frontend and other dependencies. Make sure you're using Dart Sass 1.49.10 or greater, and then if you're:
 
 - calling the Sass compiler from the command line, [pass the `--quiet-deps` flag](https://sass-lang.com/documentation/cli/dart-sass#quiet-deps)
 - using the JavaScript API, [include `quietDeps: true`](https://sass-lang.com/documentation/js-api#quietdeps) in the `options` object


### PR DESCRIPTION
Dart Sass v1.49.10 [also silences compiler warnings coming from mixins and functions that are defined in GOV.UK Frontend even when they're called from application stylesheets][1].

So:

- Dart Sass >= 1.33.0 < 1.35.0 – deprecation warnings are emitted that cannot be silenced
- Dart Sass >= 1.35.0 < 1.49.10 – deprecation warnings coming from ‘within’ GOV.UK Frontend can be silenced using quiet deps, but if application stylesheets call a mixin or function from GOV.UK Frontend that uses / for division the warning will still be emitted
- Dart Sass >= 1.49.10 – all deprecation warnings coming from ‘within’ GOV.UK Frontend can be silenced using quiet deps, even when coming from within GOV.UK Frontend mixins or functions called from application stylesheets

I see little benefit in distinguishing between the two, as there is no downside to using 1.49.10 over 1.35.0. As such we can just tell users to use 1.49.10 or greater.

[1]: https://github.com/sass/dart-sass/releases/tag/1.49.10