### PR TITLE
Strengthen message around LibSass and Ruby Sass

### DIFF
--- a/source/installing-with-npm/index.html.md.erb
+++ b/source/installing-with-npm/index.html.md.erb
@@ -21,14 +21,9 @@ weight: 10
 
     If you're using Dart Sass 1.33.0 or greater, you may see deprecation warnings when compiling your Sass. You can [silence deprecation warnings caused by dependencies](/importing-css-assets-and-javascript/#silence-deprecation-warnings-from-dependencies-in-dart-sass) if required.
 
-    We recommend you do not use either LibSass or Ruby Sass, as they are deprecated.
+    Do not use either LibSass or Ruby Sass, which are deprecated, for new projects.
 
-    Currently, GOV.UK Frontend supports:
-
-- LibSass - version 3.3.0 and greater
-- Ruby Sass - version 3.4.0 and greater
-
-    However, we may stop supporting LibSass and Ruby Sass in future.
+    Although GOV.UK Frontend currently supports LibSass (version 3.3.0 and above) and Ruby Sass (version 3.4.0 and above), we will remove support in future. If you're using either of these Sass compilers, you should [migrate to Dart Sass](https://sass-lang.com/blog/libsass-is-deprecated#how-do-i-migrate) as soon as you reasonably can.
 
 You can also [install Nunjucks v3.0.0 or later](https://www.npmjs.com/package/nunjucks) if you want to [use GOV.UK Frontend's Nunjucks macros](/use-nunjucks/).
 


### PR DESCRIPTION
Make it more explicit that GOV.UK Frontend will drop support for LibSass and Ruby Sass at some point in the future.