### PR TITLE
Update Frontend install doc about drop of support for Ruby Sass and LibSass

### DIFF
--- a/source/installing-with-npm/index.html.md.erb
+++ b/source/installing-with-npm/index.html.md.erb
@@ -21,9 +21,7 @@ weight: 10
 
     If you're using Dart Sass 1.33.0 or greater, you may see deprecation warnings when compiling your Sass. You can [silence deprecation warnings caused by dependencies](/importing-css-assets-and-javascript/#silence-deprecation-warnings-from-dependencies-in-dart-sass) if required.
 
-    Do not use either LibSass or Ruby Sass, which are deprecated, for new projects.
-
-    Although GOV.UK Frontend currently supports LibSass (version 3.3.0 and above) and Ruby Sass (version 3.4.0 and above), we will remove support in future. If you're using either of these Sass compilers, you should [migrate to Dart Sass](https://sass-lang.com/blog/libsass-is-deprecated#how-do-i-migrate) as soon as you reasonably can.
+    Do not use either LibSass or Ruby Sass, as GOV.UK Frontend does not support them. If you're using either of these deprecated Sass compilers, you should [migrate to Dart Sass](https://sass-lang.com/blog/libsass-is-deprecated#how-do-i-migrate) as soon as possible.
 
 You can also [install Nunjucks v3.0.0 or later](https://www.npmjs.com/package/nunjucks) if you want to [use GOV.UK Frontend's Nunjucks macros](/use-nunjucks/).
 


### PR DESCRIPTION
Partly fixes [#2637](https://github.com/alphagov/govuk-frontend/issues/2637).

This PR updates our 'Install with npm' doc to reflect our dropping support for LibSass and Ruby Sass.