### PR TITLE
Remove unnecessary guidance for webpack

### DIFF
--- a/source/importing-css-assets-and-javascript/index.html.md.erb
+++ b/source/importing-css-assets-and-javascript/index.html.md.erb
@@ -205,25 +205,6 @@ import { initAll } from 'govuk-frontend'
 initAll()
 ```
 
-If you're using Webpack, you may need to add some or all of the following to your Webpack config file:
-
-```json
-resolve: {
-  extensions: ['.mjs'],
-},
-module: {
-  rules: [
-    {
-      test: /\.mjs$/,
-      type: 'javascript/auto',
-      resolve: {
-        fullySpecified: false
-      }
-    }
-  ]
-}
-```
-
 If you're using a bundler that uses CommonJS like [Browserify](http://browserify.org/), you should use `require`:
 
 ```javascript


### PR DESCRIPTION
We added this guidance for govuk-frontend v4.1.0 - when we [added the ability to use ES Modules](https://github.com/alphagov/govuk-frontend/releases/tag/v4.1.0) - because our imports were not fully specified (ie: they did not have file extensions). We've [fixed this for v4.1.1](https://github.com/alphagov/govuk-frontend/pull/2658), and this guidance now looks to be unneeded.

Part of #194