### PR TITLE
Reference test workflow locally

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -10,7 +10,7 @@ concurrency: production
 
 jobs:
   build:
-    uses: alphagov/govuk-frontend-docs/.github/workflows/test.yaml@0d785a0facd18da341b60af9df0c429044b94464
+    uses: ./.github/workflows/test.yaml
     with:
       upload-artifact: true
 


### PR DESCRIPTION
GitHub have now [made it possible to reference other workflows locally, rather than needing to specify the repo and version][1].

Update the deploy workflow, which 'uses' the test workflow, to adopt this new, simpler approach.

Mimics [a change we made to the Design System deploy workflow back in January][2]

[1]: https://github.blog/changelog/2022-01-25-github-actions-reusable-workflows-can-be-referenced-locally/
[2]: https://github.com/alphagov/govuk-design-system/commit/91da7ea612a9bed8e8942b369fd26e9c2df0a878