### PR TITLE
Update all dependencies using Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,13 @@ updates:
     allow:
       - dependency-type: all
 
+  # Update Ruby gems
+  - package-ecosystem: bundler
+    directory: /
+    reviewers:
+      - alphagov/design-system-developers
+    schedule:
+      interval: daily
+    allow:
+      - dependency-type: all
+

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,10 @@ updates:
     allow:
       - dependency-type: all
 
+  # Update GitHub Actions
+  - package-ecosystem: github-actions
+    directory: /
+    reviewers:
+      - alphagov/design-system-developers
+    schedule:
+      interval: daily

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+
+updates:
+
+  # Update npm packages
+  - package-ecosystem: npm
+    directory: /
+    reviewers:
+      - alphagov/design-system-developers
+    schedule:
+      interval: daily
+    allow:
+      - dependency-type: all
+

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
       - alphagov/design-system-developers
     schedule:
       interval: daily
+    versioning-strategy: increase
+
     allow:
       - dependency-type: all
 
@@ -19,6 +21,8 @@ updates:
       - alphagov/design-system-developers
     schedule:
       interval: daily
+    versioning-strategy: increase
+
     allow:
       - dependency-type: all
 


### PR DESCRIPTION
This PR enables Dependabot updates for npm, Ruby gems and GitHub Actions

Previously only security-related updates were included