### PR TITLE
Work around table of contents bug

### DIFF
--- a/source/javascript-api-reference/index.html.md.erb
+++ b/source/javascript-api-reference/index.html.md.erb
@@ -30,7 +30,7 @@ GOVUKFrontend.initAll({
 })
 ```
 
-## Accordion
+## Accordion component
 
 ### i18n
 
@@ -117,7 +117,7 @@ Default:
 "Show this section"
 ```
 
-## Button
+## Button component
 
 ### preventDoubleClick
 
@@ -131,7 +131,7 @@ Default:
 false
 ```
 
-## CharacterCount
+## CharacterCount component
 
 ### maxlength
 
@@ -287,7 +287,7 @@ Default:
 }
 ```
 
-## ErrorSummary
+## ErrorSummary component
 
 ### disableAutoFocus
 
@@ -301,7 +301,7 @@ Default
 false
 ```
 
-## NotificationBanner
+## NotificationBanner component
 
 ### `disableAutoFocus`
 


### PR DESCRIPTION
There appears to be a bug in the way that the tech docs generates unique identifies for headings.

The link to the 'Button' component in the JS API Reference from the Sass API reference is incorrect because the Sass API Reference _also_ has a heading called 'Button' and this is incorrectly taken into consideration when building the nav even though we're linking to a different page.

Work around this by adding the word component to every H2 to make the headings unique, until we can fix the bug in the tech docs gem.