### PR TITLE
Update to use govuk-frontend 4.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "hasInstallScript": true,
       "devDependencies": {
-        "govuk-frontend": "^4.4.0",
+        "govuk-frontend": "^4.4.1",
         "hyperlink": "^5.0.4",
         "sassdoc": "^2.7.4",
         "standard": "^17.0.0",
@@ -4205,9 +4205,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.4.0.tgz",
-      "integrity": "sha512-3Hg4GePCdlynd7F6a3YPOEJx0lDPPP6iBv1S893tv3+efYGWLGvsSFdCG0uob8Xc1O7ckL19dSsFpFhBWUkTNA==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.4.1.tgz",
+      "integrity": "sha512-Jm1LUWiH9vy47b6HSH/ksSb4ueBrtTTgyLBk+3X2qqAmmFUc1AXWLSYHid07YYu1tvn9RnodWk5Bac5Ywqk6tA==",
       "dev": true,
       "engines": {
         "node": ">= 4.2.0"
@@ -13777,9 +13777,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.4.0.tgz",
-      "integrity": "sha512-3Hg4GePCdlynd7F6a3YPOEJx0lDPPP6iBv1S893tv3+efYGWLGvsSFdCG0uob8Xc1O7ckL19dSsFpFhBWUkTNA==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.4.1.tgz",
+      "integrity": "sha512-Jm1LUWiH9vy47b6HSH/ksSb4ueBrtTTgyLBk+3X2qqAmmFUc1AXWLSYHid07YYu1tvn9RnodWk5Bac5Ywqk6tA==",
       "dev": true
     },
     "graceful-fs": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "check-links": "hyperlink -ri deploy/public/index.html --skip 'property=\"og:url\"' | tap-spot"
   },
   "devDependencies": {
-    "govuk-frontend": "^4.4.0",
+    "govuk-frontend": "^4.4.1",
     "hyperlink": "^5.0.4",
     "sassdoc": "^2.7.4",
     "standard": "^17.0.0",


### PR DESCRIPTION
Closes #269.

It only updates the version number for npm as the version number in the content is meant to reference an old version given the text preceeding it.