### PR TITLE
Load our govuk-frontend package before the tech_docs_gem

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -10,6 +10,11 @@ config[:build_dir] = "deploy/public"
 
 GovukTechDocs.configure(self)
 
+# Load our own version of GOV.UK Frontend before the one registered by the
+# tech_docs_gem otherwise we may be using styles and scripts
+# from an outdated version the time for the tech_docs_gem to catch up
+self.sprockets.prepend_path File.join(__dir__, "./node_modules/govuk-frontend/")
+
 # Prevent pages from being indexed unless GitHub Actions is building the main branch
 config[:tech_docs][:prevent_indexing] = (ENV["GITHUB_REF"] != "refs/heads/main")
 


### PR DESCRIPTION
This makes Sprockets point to whichever version we defined in this repository rather that the one set in its own dependencies and [loaded there](https://github.com/alphagov/tech-docs-gem/blob/d3a1545158c5f9c78caafcbbbd7ddd097fdeedcb/lib/govuk_tech_docs.rb\#L35).

This ensure we're using styles and scripts from the version we set and saves us waiting for the tech_docs_gem to have updated.