### PR TITLE
Configure Dependabot for direct updates only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,7 +24,7 @@ updates:
     versioning-strategy: increase
 
     allow:
-      - dependency-type: all
+      - dependency-type: direct
 
   # Update GitHub Actions
   - package-ecosystem: github-actions

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
     versioning-strategy: increase
 
     allow:
-      - dependency-type: all
+      - dependency-type: direct
 
   # Update Ruby gems
   - package-ecosystem: bundler


### PR DESCRIPTION
This PR configures Dependabot to only allow updates to [`direct` dependencies](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#allow)

See https://github.com/alphagov/govuk-frontend/pull/3132 for more info:

>We regularly receive Dependabot PRs for “dependencies of dependencies” **package-lock.json** changes. It's great for [**Dependabot security updates** via Settings](https://github.com/alphagov/govuk-frontend/settings/security_analysis) it's but too noisy for [**Dependabot version updates** via `dependabot.yml`](https://github.com/alphagov/govuk-frontend/blob/main/.github/dependabot.yml)
>
>For example updates to  [`indirect` dependencies](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#allow) don't appear in `npm outdated`:
>
>1. `@babel/helper-*`
>2. `@babel/plugin-*`
>3. `@babel/types`
>4. `core-js-compat`
>5. `semver`
>
>Yet they will still be included in a single PR update for [`@babel/preset-env`](https://www.npmjs.com/package/@babel/preset-env) by the author
>
>Should we narrow down our non-security version updates to direct-only?