### PR TITLE
Reduce dependabot updates frequency to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,11 @@ updates:
     reviewers:
       - alphagov/design-system-developers
     schedule:
-      interval: daily
+      # Defaults to weekly on Monday
+      interval: weekly
+      time: "10:30"
+      # Setting a timezone so we let dependabot worry about BST
+      timezone: "Europe/London"
     versioning-strategy: increase
 
     allow:
@@ -20,7 +24,11 @@ updates:
     reviewers:
       - alphagov/design-system-developers
     schedule:
-      interval: daily
+      # Defaults to weekly on Monday
+      interval: weekly
+      time: "10:30"
+      # Setting a timezone so we let dependabot worry about BST
+      timezone: "Europe/London"
     versioning-strategy: increase
 
     allow:
@@ -32,4 +40,8 @@ updates:
     reviewers:
       - alphagov/design-system-developers
     schedule:
-      interval: daily
+      # Defaults to weekly on Monday
+      interval: weekly
+      time: "10:30"
+      # Setting a timezone so we let dependabot worry about BST
+      timezone: "Europe/London"


### PR DESCRIPTION
Reduces Dependabot updates frequency so it runs weekly on Monday (default) at 10:30 (some time in the day rather than before everyone is in, in the hopes to spread who picks these up a little more). 

This change of frequency shouldn't affect when Dependabot raises security updates (according to this [bit of Dependabot's documentation](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates#frequency-of-dependabot-pull-requests))

Closes [#3349](https://github.com/alphagov/govuk-frontend/issues/3349)