### PR TITLE
Preview v5: Update examples using ES modules

### DIFF
--- a/source/compatibility-mode/index.html.md.erb
+++ b/source/compatibility-mode/index.html.md.erb
@@ -24,7 +24,7 @@ GOV.UK Frontend will:
 
 ## Turn on 'compatibility mode'
 
-Add one or more of the following lines to your project's Sass file, above `@import "govuk-frontend/govuk/all"`:
+Add one or more of the following lines to your project's Sass file, above `@import "govuk-frontend/dist/govuk/all"`:
 
 - `$govuk-compatibility-govukelements: true;` if you're using GOV.UK Elements
 - `$govuk-compatibility-govuktemplate: true;` if you're using GOV.UK Template
@@ -42,7 +42,7 @@ Remove the following lines from your project's Sass file:
 
 If you’re not using any of our old frameworks, you can still configure GOV.UK Frontend to use the old colour palette.
 
-Add the following variable to your project's Sass file, above `@import "govuk-frontend/govuk/all"`:
+Add the following variable to your project's Sass file, above `@import "govuk-frontend/dist/govuk/all"`:
 
 ```scss
 $govuk-use-legacy-palette: true;

--- a/source/configure-components-with-javascript/index.html.md.erb
+++ b/source/configure-components-with-javascript/index.html.md.erb
@@ -73,7 +73,7 @@ new CharacterCount($element, {
       one: "%{count} character to go"
     }
   }
-}).init()
+})
 ```
 
 Read the [JavaScript API Reference](/javascript-api-reference/) to see what configuration each component accepts.

--- a/source/configure-components-with-javascript/index.html.md.erb
+++ b/source/configure-components-with-javascript/index.html.md.erb
@@ -83,7 +83,7 @@ Read the [JavaScript API Reference](/javascript-api-reference/) to see what conf
 You can pass configuration for components when initialising GOV.UK Frontend using the `initAll` function. You can do this by including key-value pairs of camel-cased component names and configuration objects. This is the same method you would use to pass them when creating an instance of the component. For example:
 
 ```javascript
-window.GOVUKFrontend.initAll({
+initAll({
   characterCount: {
     maxlength: 500, // Non namespaced
     i18n: { // i18n namespace

--- a/source/get-started/index.html.md.erb
+++ b/source/get-started/index.html.md.erb
@@ -32,7 +32,7 @@ Paste the HTML into a page or template in your application.
 1. Add the following to the main Sass file in your project, so your Sass compiler adds all of GOV.UK Frontend's styles to your CSS file.
 
     ```scss
-    @import "node_modules/govuk-frontend/govuk/all";
+    @import "node_modules/govuk-frontend/dist/govuk/all";
     ```
 
 2. Add your CSS file to your page layout if you need to. For example:
@@ -55,8 +55,8 @@ There are also different ways you can [import GOV.UK Frontend's CSS](/importing-
 Your component will not use the right font or images until you've added GOV.UK Frontend's assets to your application.
 
 1. Copy the following 2 folders:
-  - `/node_modules/govuk-frontend/govuk/assets/images` folder to `<YOUR-APP>/assets/images`
-  - `/node_modules/govuk-frontend/govuk/assets/fonts` folder to `<YOUR-APP>/assets/fonts`
+  - `/node_modules/govuk-frontend/dist/govuk/assets/images` folder to `<YOUR-APP>/assets/images`
+  - `/node_modules/govuk-frontend/dist/govuk/assets/fonts` folder to `<YOUR-APP>/assets/fonts`
 
 2. Run your application, then use [the Fonts tab in Firefox Page Inspector](https://developer.mozilla.org/en-US/docs/Tools/Page_Inspector/How_to/Edit_fonts#The_Fonts_tab) to check the accordion is using the GDS Transport font.
 
@@ -70,14 +70,14 @@ In your live application, we recommend [using an automated task or your build pi
     <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
     ```
 
-2. Copy the `/node-modules/govuk-frontend/govuk/all.js` file to `<YOUR-JAVASCRIPT-FOLDER>/govuk.js`.
+2. Copy the `/node-modules/govuk-frontend/dist/govuk/govuk-frontend.min.js` file into your application.
 
 3. Import the file before the closing `</body>` tag of your page template, then run the `initAll` function to initialise all the components. For example:
 
     ```html
     <body>
       ...
-      <script src="<YOUR-JAVASCRIPT-FOLDER>/govuk.js"></script>
+      <script src="<YOUR-JAVASCRIPT-FOLDER>/govuk-frontend.min.js"></script>
       <script>
         window.GOVUKFrontend.initAll()
       </script>

--- a/source/get-started/index.html.md.erb
+++ b/source/get-started/index.html.md.erb
@@ -40,7 +40,7 @@ Paste the HTML into a page or template in your application.
     ```html
       <head>
         ...
-        <link rel="stylesheet" href="<YOUR-CSS-FILE>.css">
+        <link rel="stylesheet" href="<YOUR-STYLESHEETS-FOLDER>/<YOUR-CSS-FILE>.css">
       </head>
     ```
 
@@ -77,7 +77,7 @@ In your live application, we recommend [using an automated task or your build pi
     ```html
     <body>
       ...
-      <script src="<YOUR-JAVASCRIPT-FOLDER>/govuk-frontend.min.js"></script>
+      <script src="<YOUR-JAVASCRIPTS-FOLDER>/govuk-frontend.min.js"></script>
       <script>
         window.GOVUKFrontend.initAll()
       </script>

--- a/source/get-started/index.html.md.erb
+++ b/source/get-started/index.html.md.erb
@@ -77,9 +77,10 @@ In your live application, we recommend [using an automated task or your build pi
     ```html
     <body>
       ...
-      <script src="<YOUR-JAVASCRIPTS-FOLDER>/govuk-frontend.min.js"></script>
-      <script>
-        window.GOVUKFrontend.initAll()
+      <script type="module" src="<YOUR-JAVASCRIPTS-FOLDER>/govuk-frontend.min.js"></script>
+      <script type="module">
+        import { initAll } from '<YOUR-JAVASCRIPTS-FOLDER>/govuk-frontend.min.js'
+        initAll()
       </script>
     </body>
     ```

--- a/source/importing-css-assets-and-javascript/index.html.md.erb
+++ b/source/importing-css-assets-and-javascript/index.html.md.erb
@@ -174,7 +174,7 @@ You can select and initialise a specific component by using its `data-module` at
     import { Radios } from '<YOUR-JAVASCRIPTS-FOLDER>/govuk-frontend.min.js'
     const $radio = document.querySelector('[data-module="govuk-radios"]')
     if ($radio) {
-      new Radios($radio).init()
+      new Radios($radio)
     }
   </script>
 ```
@@ -188,12 +188,12 @@ import { SkipLink, Radios } from 'govuk-frontend'
 
 const $skipLink = document.querySelector('[data-module="govuk-skip-link"]')
 if ($skipLink) {
-  new SkipLink($skipLink).init()
+  new SkipLink($skipLink)
 }
 
 const $radios = document.querySelectorAll('[data-module="govuk-radios]')
 $radios.forEach(($radio) => {
-  new Radios($radio).init()
+  new Radios($radio)
 })
 ```
 

--- a/source/importing-css-assets-and-javascript/index.html.md.erb
+++ b/source/importing-css-assets-and-javascript/index.html.md.erb
@@ -157,9 +157,10 @@ Then import the JavaScript file before the closing `</body>` tag of your HTML pa
 ```html
 <body>
 ...
-  <script src="<YOUR-JAVASCRIPTS-FOLDER>/govuk-frontend.min.js"></script>
-  <script>
-    window.GOVUKFrontend.initAll()
+  <script type="module" src="<YOUR-JAVASCRIPTS-FOLDER>/govuk-frontend.min.js"></script>
+  <script type="module">
+    import { initAll } from '<YOUR-JAVASCRIPTS-FOLDER>/govuk-frontend.min.js'
+    initAll()
   </script>
 </body>
 ```
@@ -169,9 +170,9 @@ Then import the JavaScript file before the closing `</body>` tag of your HTML pa
 You can select and initialise a specific component by using its `data-module` attribute. For example, use `govuk-radios` to initialise the first radio component on a page:
 
 ```html
-  <script>
-    var Radios = window.GOVUKFrontend.Radios
-    var $radio = document.querySelector('[data-module="govuk-radios"]')
+  <script type="module">
+    import { Radios } from '<YOUR-JAVASCRIPTS-FOLDER>/govuk-frontend.min.js'
+    const $radio = document.querySelector('[data-module="govuk-radios"]')
     if ($radio) {
       new Radios($radio).init()
     }
@@ -208,8 +209,8 @@ initAll()
 If you're using a bundler that uses CommonJS like [Browserify](http://browserify.org/), you should use `require`:
 
 ```javascript
-const GOVUKFrontend = require('govuk-frontend')
-GOVUKFrontend.initAll()
+const { initAll } = require('govuk-frontend')
+initAll()
 ```
 
 ### Select and initialise part of a page
@@ -219,9 +220,10 @@ If you update a page with new markup, for example a modal dialogue box, you can 
 For example:
 
 ```html
-  <script>
-    var $modal = document.querySelector('.modal')
-    window.GOVUKFrontend.initAll({
+  <script type="module">
+    import { initAll } from '<YOUR-JAVASCRIPTS-FOLDER>/govuk-frontend.min.js'
+    const $modal = document.querySelector('.modal')
+    initAll({
       scope: $modal
     })
   </script>

--- a/source/importing-css-assets-and-javascript/index.html.md.erb
+++ b/source/importing-css-assets-and-javascript/index.html.md.erb
@@ -12,53 +12,53 @@ weight: 70
 To import all the Sass rules from GOV.UK Frontend, add the following to your Sass file:
 
 ```scss
-@import "node_modules/govuk-frontend/govuk/all";
+@import "node_modules/govuk-frontend/dist/govuk/all";
 ```
 
 ### Import specific parts of the CSS
 
 If you want to improve how quickly your service's pages load in browsers, you can import only the Sass rules you need.
 
-1. Import `node_modules/govuk-frontend/govuk/base` in your Sass file.
+1. Import `node_modules/govuk-frontend/dist/govuk/base` in your Sass file.
 2. Import the parts of the CSS you need.
 
 For example, add the following to your Sass file to import the CSS you need for a basic GOV.UK page.
 
 ```scss
-@import "node_modules/govuk-frontend/govuk/base";
+@import "node_modules/govuk-frontend/dist/govuk/base";
 
-@import "node_modules/govuk-frontend/govuk/core/all";
-@import "node_modules/govuk-frontend/govuk/objects/all";
-@import "node_modules/govuk-frontend/govuk/components/footer/index";
-@import "node_modules/govuk-frontend/govuk/components/header/index";
-@import "node_modules/govuk-frontend/govuk/components/skip-link/index";
-@import "node_modules/govuk-frontend/govuk/utilities/all";
-@import "node_modules/govuk-frontend/govuk/overrides/all";
+@import "node_modules/govuk-frontend/dist/govuk/core/all";
+@import "node_modules/govuk-frontend/dist/govuk/objects/all";
+@import "node_modules/govuk-frontend/dist/govuk/components/footer/index";
+@import "node_modules/govuk-frontend/dist/govuk/components/header/index";
+@import "node_modules/govuk-frontend/dist/govuk/components/skip-link/index";
+@import "node_modules/govuk-frontend/dist/govuk/utilities/all";
+@import "node_modules/govuk-frontend/dist/govuk/overrides/all";
 ```
 You can remove lines that import parts of the CSS you do not need.
 
-[Read more about the different parts of GOV.UK Frontend’s CSS](https://github.com/alphagov/govuk-frontend/tree/master/src/govuk).
+[Read more about the different parts of GOV.UK Frontend’s CSS](https://github.com/alphagov/govuk-frontend/tree/main/packages/govuk-frontend/src).
 
 You do not need `/index` at the end of your component imports if you’re using Dart Sass, LibSass 3.6.0 or higher, or Ruby Sass 3.6.0 or higher.
 
 ### Import an individual component’s CSS using a single import
 
-You can also import a component and all its dependencies without importing `node_modules/govuk-frontend/govuk/base` first.
+You can also import a component and all its dependencies without importing `node_modules/govuk-frontend/dist/govuk/base` first.
 
 To import the button component for example, add the following to your Sass file:
 
 ```scss
-@import "node_modules/govuk-frontend/govuk/components/button/button";
+@import "node_modules/govuk-frontend/dist/govuk/components/button/button";
 ```
 
 ### Simplify Sass import paths
 
-If you want to make Sass import paths shorter, add `node_modules/govuk-frontend` to either your:
+If you want to make Sass import paths shorter, add `node_modules/govuk-frontend/dist` to either your:
 
 - [Sass load paths](https://sass-lang.com/documentation/at-rules/import#finding-the-file)
 - [assets paths](http://guides.rubyonrails.org/asset_pipeline.html#search-paths) if you use Ruby in your project
 
-You can then import without using `node_modules/govuk-frontend/` in your import path. For example:
+You can then import without using `node_modules/govuk-frontend/dist/` in your import path. For example:
 
 ```scss
 @import "govuk/components/button/button";
@@ -96,21 +96,21 @@ To use the font and image assets from GOV.UK Frontend, you can either:
 
 ### Serve the assets from the GOV.UK Frontend assets folder - recommended
 
-Set up your routing so that requests for files in `<YOUR-SITE-URL>/assets` are served from `/node_modules/govuk-frontend/govuk/assets`.
+Set up your routing so that requests for files in `<YOUR-SITE-URL>/assets` are served from `/node_modules/govuk-frontend/dist/govuk/assets`.
 
 For example if you're using [express.js](https://expressjs.com/), add the following to your `app.js` file:
 
 ```javascript
 var path = require('path');
-app.use('/assets', express.static(path.join(__dirname, '/node_modules/govuk-frontend/govuk/assets')))
+app.use('/assets', express.static(path.join(__dirname, '/node_modules/govuk-frontend/dist/govuk/assets')))
 ```
 
 ### Copy the font and image files into your application
 
 If you decide to copy the assets instead, copy the:
 
-- `/node_modules/govuk-frontend/govuk/assets/images` folder to `<YOUR-APP>/assets/images`
-- `/node_modules/govuk-frontend/govuk/assets/fonts` folder to `<YOUR-APP>/assets/fonts`
+- `/node_modules/govuk-frontend/dist/govuk/assets/images` folder to `<YOUR-APP>/assets/images`
+- `/node_modules/govuk-frontend/dist/govuk/assets/fonts` folder to `<YOUR-APP>/assets/fonts`
 
 You should use an automated task or your build pipeline to copy the files, so your project folder stays up to date when we update GOV.UK Frontend.
 
@@ -149,15 +149,15 @@ To import the JavaScript from GOV.UK Frontend, you can either:
 
 If you decide to add the JavaScript to your HTML, first either:
 
-- set up your routing so that requests for the JavaScript file are served from  `node_modules/govuk-frontend/govuk/all.js`
-- copy the `node_modules/govuk-frontend/govuk/all.js` file into your application
+- set up your routing so that requests for the JavaScript file are served from  `node_modules/govuk-frontend/dist/govuk/govuk-frontend.min.js`
+- copy the `node_modules/govuk-frontend/dist/govuk/govuk-frontend.min.js` file into your application
 
 Then import the JavaScript file before the closing `</body>` tag of your HTML page or page template, and run the `initAll` function to initialise all the components.
 
 ```html
 <body>
 ...
-  <script src="<YOUR-APP>/<YOUR-JS-FILE>.js"></script>
+  <script src="<YOUR-APP>/govuk-frontend.min.js"></script>
   <script>
     window.GOVUKFrontend.initAll()
   </script>

--- a/source/importing-css-assets-and-javascript/index.html.md.erb
+++ b/source/importing-css-assets-and-javascript/index.html.md.erb
@@ -101,7 +101,7 @@ Set up your routing so that requests for files in `<YOUR-SITE-URL>/assets` are s
 For example if you're using [express.js](https://expressjs.com/), add the following to your `app.js` file:
 
 ```javascript
-var path = require('path');
+const path = require('path');
 app.use('/assets', express.static(path.join(__dirname, '/node_modules/govuk-frontend/dist/govuk/assets')))
 ```
 
@@ -186,17 +186,15 @@ If you decide to import using a bundler, we recommend you use `import` to only i
 ```javascript
 import { SkipLink, Radios } from 'govuk-frontend'
 
-var $skipLink = document.querySelector('[data-module="govuk-skip-link"]')
+const $skipLink = document.querySelector('[data-module="govuk-skip-link"]')
 if ($skipLink) {
   new SkipLink($skipLink).init()
 }
 
-var $radios = document.querySelectorAll('[data-module="govuk-radios]')
-if ($radios) {
-  for (var i = 0; i < $radios.length; i++) {
-    new Radios($radios[i]).init()
-  }
-}
+const $radios = document.querySelectorAll('[data-module="govuk-radios]')
+$radios.forEach(($radio) => {
+  new Radios($radio).init()
+})
 ```
 
 If you need to import all of GOV.UK Frontend's components, then run the `initAll` function to initialise them:

--- a/source/importing-css-assets-and-javascript/index.html.md.erb
+++ b/source/importing-css-assets-and-javascript/index.html.md.erb
@@ -157,7 +157,7 @@ Then import the JavaScript file before the closing `</body>` tag of your HTML pa
 ```html
 <body>
 ...
-  <script src="<YOUR-APP>/govuk-frontend.min.js"></script>
+  <script src="<YOUR-JAVASCRIPTS-FOLDER>/govuk-frontend.min.js"></script>
   <script>
     window.GOVUKFrontend.initAll()
   </script>

--- a/source/install-using-precompiled-files/index.html.md.erb
+++ b/source/install-using-precompiled-files/index.html.md.erb
@@ -49,9 +49,10 @@ You’ll not be able to:
           document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
         </script>
         <!-- component HTML -->
-        <script src="/javascripts/govuk-frontend-<VERSION-NUMBER>.min.js"></script>
-        <script>
-          window.GOVUKFrontend.initAll()
+        <script type="module" src="/javascripts/govuk-frontend-<VERSION-NUMBER>.min.js"></script>
+        <script type="module">
+          import { initAll } from '/javascripts/govuk-frontend-<VERSION-NUMBER>.min.js'
+          initAll()
         </script>
       </body>
     </html>

--- a/source/install-using-precompiled-files/index.html.md.erb
+++ b/source/install-using-precompiled-files/index.html.md.erb
@@ -25,7 +25,7 @@ You’ll not be able to:
 2. Unzip the zip file.
 3. Copy the `assets` folder to the root of your project’s public folder, so that for example `<YOUR-SITE-URL>/assets/govuk-logotype-crown.png` shows the `govuk-logotype-crown.png` image in your users’ browsers.
 4. Copy the 2 `.css` files to a stylesheets folder in the root of your project’s public folder, so that for example `<YOUR-SITE-URL>/stylesheets/govuk-frontend-<VERSION-NUMBER>.min.css` shows the CSS file in your users’ browsers.
-5. Copy the `.js` file to a JavaScript folder in the root of your project’s public folder, so that for example `<YOUR-SITE-URL>/javascript/govuk-frontend-<VERSION-NUMBER>.min.js` shows the JavaScript file in your users’ browsers.
+5. Copy the `.js` file to a JavaScript folder in the root of your project’s public folder, so that for example `<YOUR-SITE-URL>/javascripts/govuk-frontend-<VERSION-NUMBER>.min.js` shows the JavaScript file in your users’ browsers.
 
 ## Check an example page
 
@@ -49,7 +49,7 @@ You’ll not be able to:
           document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
         </script>
         <!-- component HTML -->
-        <script src="/javascript/govuk-frontend-<VERSION-NUMBER>.min.js"></script>
+        <script src="/javascripts/govuk-frontend-<VERSION-NUMBER>.min.js"></script>
         <script>
           window.GOVUKFrontend.initAll()
         </script>

--- a/source/javascript-api-reference/index.html.md.erb
+++ b/source/javascript-api-reference/index.html.md.erb
@@ -21,7 +21,7 @@ For example, to set the `preventDoubleClick` option of a button:
 import { Button, initAll } from '<YOUR-APP>/govuk-frontend.min.js'
 
 // Creating a single instance
-var button = document.querySelector('[data-module="button"]')
+const button = document.querySelector('[data-module="button"]')
 new Button(button, { preventDoubleClick: true })
 
 // Or when using initAll

--- a/source/javascript-api-reference/index.html.md.erb
+++ b/source/javascript-api-reference/index.html.md.erb
@@ -18,12 +18,14 @@ You can pass these options in an object either as:
 For example, to set the `preventDoubleClick` option of a button:
 
 ```javascript
+import { Button, initAll } from '<YOUR-APP>/govuk-frontend.min.js'
+
 // Creating a single instance
 var button = document.querySelector('[data-module="button"]')
-new GOVUKFrontend.Button(button, {preventDoubleClick: true})
+new Button(button, { preventDoubleClick: true })
 
 // Or when using initAll
-GOVUKFrontend.initAll({
+initAll({
   button: {
     preventDoubleClick: true
   }
@@ -52,7 +54,7 @@ The text content for the 'Hide all sections' button, used when at least one
 section is expanded.
 
 Default:
-  
+
 ```json
 "Hide all sections"
 ```
@@ -180,7 +182,7 @@ number of remaining characters. This is a [pluralised list of
 messages](/localise-govuk-frontend/#understanding-pluralisation-rules).
 
 Default:
-  
+
 ```json
 {
   one: "You have %{count} character remaining",

--- a/source/javascript-api-reference/index.html.md.erb
+++ b/source/javascript-api-reference/index.html.md.erb
@@ -21,8 +21,8 @@ For example, to set the `preventDoubleClick` option of a button:
 import { Button, initAll } from '<YOUR-APP>/govuk-frontend.min.js'
 
 // Creating a single instance
-const button = document.querySelector('[data-module="button"]')
-new Button(button, { preventDoubleClick: true })
+const $button = document.querySelector('[data-module="button"]')
+new Button($button, { preventDoubleClick: true })
 
 // Or when using initAll
 initAll({

--- a/source/localise-govuk-frontend/index.html.md.erb
+++ b/source/localise-govuk-frontend/index.html.md.erb
@@ -118,7 +118,7 @@ With Nunjucks
 With data attributes
 
 ```html
-<div data-module="character-count" 
+<div data-module="character-count"
   data-i18n.characters-under-limit.other="%{count} characters to go"
   data-i18n.characters-under-limit.one="One character to go"
   data-i18n.characters-over-limit.one="One character too many">
@@ -139,5 +139,5 @@ new CharacterCount($element, {
       // The `other` key for `characterOverLimit` will be our default
     }
   }
-}).init()
+})
 ```

--- a/source/testing-your-html/index.html.md.erb
+++ b/source/testing-your-html/index.html.md.erb
@@ -12,9 +12,9 @@ You can use our test fixtures to check you're outputting the same HTML that GOV.
 
 ## Using the HTML test files
 
-If you [installed GOV.UK Frontend with Node.js package manager (npm)](/installing-with-npm), you can find the `fixtures.json` file for each component in the `node_modules/govuk-frontend/govuk/components/COMPONENT-NAME/` folder, where `COMPONENT-NAME` is the name of the component.
+If you [installed GOV.UK Frontend with Node.js package manager (npm)](/installing-with-npm), you can find the `fixtures.json` file for each component in the `node_modules/govuk-frontend/dist/govuk/components/COMPONENT-NAME/` folder, where `COMPONENT-NAME` is the name of the component.
 
-For example, you can find the `fixtures.json` file for the button component in the `node_modules/govuk-frontend/govuk/components/button/` folder:
+For example, you can find the `fixtures.json` file for the button component in the `node_modules/govuk-frontend/dist/govuk/components/button/` folder:
 
 ```js
 {

--- a/source/use-nunjucks/index.html.md.erb
+++ b/source/use-nunjucks/index.html.md.erb
@@ -24,13 +24,13 @@ You must first:
 
 ## Set up Nunjucks and use the page template
 
-1. Add `node_modules/govuk-frontend/` to your list of Nunjucks paths, so Nunjucks knows where to find the GOV.UK Frontend template and components.
+1. Add `node_modules/govuk-frontend/dist` to your list of Nunjucks paths, so Nunjucks knows where to find the GOV.UK Frontend template and components.
 
     For example:
 
     ```javascript
         nunjucks.configure([
-          "node_modules/govuk-frontend/",
+          "node_modules/govuk-frontend/dist",
           "YOUR-VIEWS-FOLDER"
         ])
     ```


### PR DESCRIPTION
Aligns all our examples to use `<script type="module">` for https://github.com/alphagov/govuk-frontend-docs/issues/308

Need to consider (maybe) adding a UMD example for those that need `window.GOVUKFrontend` support