### PR TITLE
Preview v5: Remove references to IE8 in code

### DIFF
--- a/lib/sassdocs_helpers.rb
+++ b/lib/sassdocs_helpers.rb
@@ -3,10 +3,6 @@ require "json"
 module SassdocsHelpers
   ORDER = %w[settings tools helpers].freeze
 
-  SPECIAL_CASES = {
-    "internet-explorer-8" => "Internet Explorer 8",
-  }.freeze
-
   def format_sassdoc_data(data)
     raise "No data in data/sassdocs.json, run `npm install` to generate." unless data.respond_to?(:sassdoc)
 
@@ -23,8 +19,8 @@ module SassdocsHelpers
 
   def mixin_trailing_code(code)
     # Some mixins can have content passed inside.
-    # For example the `govuk-if-ie8` function:
-    # @include govuk-if-ie8 {
+    # For example the `govuk-media-query` function:
+    # @include govuk-media-query($from: tablet) {
     #  //..
     # }
     accepts_content = code.include?("@content")
@@ -112,8 +108,7 @@ module SassdocsHelpers
       "General"
     elsif heading.include?("/")
       slug = heading.split("/").last
-
-      SPECIAL_CASES[slug] || slug.gsub("-", " ").capitalize
+      slug.gsub("-", " ").capitalize
     else
       "General #{heading}"
     end

--- a/source/install-using-precompiled-files/index.html.md.erb
+++ b/source/install-using-precompiled-files/index.html.md.erb
@@ -37,12 +37,7 @@ You’ll not be able to:
       <head>
         <title>Example - GOV.UK</title>
         <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-        <!--[if !IE 8]><!-->
-          <link rel="stylesheet" href="/stylesheets/govuk-frontend-<VERSION-NUMBER>.min.css">
-        <!--<![endif]-->
-        <!--[if IE 8]>
-          <link rel="stylesheet" href="/stylesheets/govuk-frontend-ie8-<VERSION-NUMBER>.min.css">
-        <![endif]-->
+        <link rel="stylesheet" href="/stylesheets/govuk-frontend-<VERSION-NUMBER>.min.css">
       </head>
       <body class="govuk-template__body ">
         <script>


### PR DESCRIPTION
Removes some IE8 references from HTML condition statements and helper code

Although the **Support Internet Explorer 8** page is actually removed in:

* https://github.com/alphagov/govuk-frontend-docs/pull/332