### PR TITLE
Preview v5: GitHub Actions fixes

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+
   workflow_dispatch:
 
 concurrency: production

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,9 +2,6 @@ name: Test
 
 on:
   pull_request:
-  push:
-    branches-ignore:
-      - main  # pushes to main are handled by deploy.yaml
 
   workflow_call:
     inputs:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,12 +5,15 @@ on:
   push:
     branches-ignore:
       - main  # pushes to main are handled by deploy.yaml
+
   workflow_call:
     inputs:
       upload-artifact:
         default: false
         required: false
         type: boolean
+
+  workflow_dispatch:
 
 jobs:
   build:

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "hyperlink": "^5.0.4",
         "sassdoc": "^2.7.4",
         "standard": "^17.1.0",
-        "tap-spot": "^1.1.2"
+        "tap-mocha-reporter": "^5.0.3"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1818,6 +1818,15 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
+    "node_modules/color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "dev": true,
+      "bin": {
+        "color-support": "bin.js"
+      }
+    },
     "node_modules/colord": {
       "version": "2.9.3",
       "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
@@ -2348,6 +2357,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/dnserrors": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/dnserrors/-/dnserrors-2.1.2.tgz",
@@ -2483,12 +2501,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/duplexer": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
-      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
-      "dev": true
     },
     "node_modules/duplexer2": {
       "version": "0.1.4",
@@ -3547,7 +3559,7 @@
     "node_modules/events-to-array": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/events-to-array/-/events-to-array-1.1.2.tgz",
-      "integrity": "sha1-LUH1Y+H+QA7Uli/hpNXGp1Od9/Y=",
+      "integrity": "sha512-inRWzRY7nG+aXZxBzEqYKB3HPgwflZRopAjDCHv0whhRx+MTUr1ei0ICZUypdyE0HRm4L2d5VEcIqLD6yl+BFA==",
       "dev": true
     },
     "node_modules/expand-brackets": {
@@ -6191,20 +6203,16 @@
       }
     },
     "node_modules/minipass": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-      "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
       "dev": true,
       "dependencies": {
-        "safe-buffer": "^5.1.2",
-        "yallist": "^3.0.0"
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
-    },
-    "node_modules/minipass/node_modules/yallist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true
     },
     "node_modules/mixin-deep": {
       "version": "1.3.2",
@@ -9040,44 +9048,84 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
     },
+    "node_modules/tap-mocha-reporter": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/tap-mocha-reporter/-/tap-mocha-reporter-5.0.3.tgz",
+      "integrity": "sha512-6zlGkaV4J+XMRFkN0X+yuw6xHbE9jyCZ3WUKfw4KxMyRGOpYSRuuQTRJyWX88WWuLdVTuFbxzwXhXuS2XE6o0g==",
+      "dev": true,
+      "dependencies": {
+        "color-support": "^1.1.0",
+        "debug": "^4.1.1",
+        "diff": "^4.0.1",
+        "escape-string-regexp": "^2.0.0",
+        "glob": "^7.0.5",
+        "tap-parser": "^11.0.0",
+        "tap-yaml": "^1.0.0",
+        "unicode-length": "^2.0.2"
+      },
+      "bin": {
+        "tap-mocha-reporter": "index.js"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/tap-mocha-reporter/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tap-mocha-reporter/node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tap-mocha-reporter/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
     "node_modules/tap-parser": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-7.0.0.tgz",
-      "integrity": "sha512-05G8/LrzqOOFvZhhAk32wsGiPZ1lfUrl+iV7+OkKgfofZxiceZWMHkKmow71YsyVQ8IvGBP2EjcIjE5gL4l5lA==",
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-11.0.2.tgz",
+      "integrity": "sha512-6qGlC956rcORw+fg7Fv1iCRAY8/bU9UabUAhs3mXRH6eRmVZcNPLheSXCYaVaYeSwx5xa/1HXZb1537YSvwDZg==",
       "dev": true,
       "dependencies": {
         "events-to-array": "^1.0.1",
-        "js-yaml": "^3.2.7",
-        "minipass": "^2.2.0"
+        "minipass": "^3.1.6",
+        "tap-yaml": "^1.0.0"
       },
       "bin": {
         "tap-parser": "bin/cmd.js"
-      }
-    },
-    "node_modules/tap-spot": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/tap-spot/-/tap-spot-1.1.2.tgz",
-      "integrity": "sha512-P1hF3JqpxvL++FNP7vuKFa1Tm8+2P7mnFINEb5A0zf8n46ulS8g+/oviYhcvXN9G+hhBaWVLie5HR6epeyxaog==",
-      "dev": true,
-      "dependencies": {
-        "chalk": "^2.3.2",
-        "duplexer": "^0.1.1",
-        "tap-parser": "^7.0.0",
-        "through2": "^2.0.1"
       },
-      "bin": {
-        "tap-dot": "bin/cmd.js",
-        "tap-spot": "bin/cmd.js"
+      "engines": {
+        "node": ">= 8"
       }
     },
-    "node_modules/tap-spot/node_modules/through2": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+    "node_modules/tap-yaml": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tap-yaml/-/tap-yaml-1.0.2.tgz",
+      "integrity": "sha512-GegASpuqBnRNdT1U+yuUPZ8rEU64pL35WPBpCISWwff4dErS2/438barz7WFJl4Nzh3Y05tfPidZnH+GaV1wMg==",
       "dev": true,
       "dependencies": {
-        "readable-stream": "~2.3.6",
-        "xtend": "~4.0.1"
+        "yaml": "^1.10.2"
       }
     },
     "node_modules/teepee": {
@@ -9477,6 +9525,15 @@
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
       "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==",
       "dev": true
+    },
+    "node_modules/unicode-length": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/unicode-length/-/unicode-length-2.1.0.tgz",
+      "integrity": "sha512-4bV582zTV9Q02RXBxSUMiuN/KHo5w4aTojuKTNT96DIKps/SIawFp7cS5Mu25VuY1AioGXrmYyzKZUzh8OqoUw==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.0.0"
+      }
     },
     "node_modules/union-value": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -6,13 +6,13 @@
     "postinstall": "npm run build:sassdoc",
     "build:sassdoc": "sassdoc --parse node_modules/govuk-frontend/dist/govuk/ > data/sassdoc.json",
     "lint": "standard",
-    "check-links": "hyperlink -ri deploy/public/index.html --skip 'property=\"og:url\"' | tap-spot"
+    "check-links": "hyperlink --canonicalroot https://frontend.design-system.service.gov.uk --internal --recursive deploy/public/index.html --skip 'property=\"og:image\"' | tap-mocha-reporter min"
   },
   "devDependencies": {
     "govuk-frontend": "github:alphagov/govuk-frontend#0f5c7975f",
     "hyperlink": "^5.0.4",
     "sassdoc": "^2.7.4",
     "standard": "^17.1.0",
-    "tap-spot": "^1.1.2"
+    "tap-mocha-reporter": "^5.0.3"
   }
 }


### PR DESCRIPTION
This PR includes a couple of GitHub Actions fixes:

1. The npm script `check-links` can fail silently
2. The checks are duplicates across `pull` and `pull_request` events

## Broken image
Matching the [GOV.UK Design System `check-links` arguments](https://github.com/alphagov/govuk-design-system/commit/85371227743245c38c6a25c89eb0e3b2157f8174) found a `--skip` argument typo

We have a broken image that should skipped with ~`property="og:url"`~ `property="og:image"`

* https://github.com/alphagov/tech-docs-gem/issues/194