### PR TITLE
Preview v5: Update application paths for `govuk-frontend@5`

### DIFF
--- a/lib/sassdocs_helpers.rb
+++ b/lib/sassdocs_helpers.rb
@@ -115,8 +115,11 @@ module SassdocsHelpers
   end
 
   def github_url(item)
+    # Maintain backwards compatibility with GOV.UK Frontend v4
+    github_package_path = govuk_frontend_version.start_with?("4") ? "/src" : "/packages/govuk-frontend/src"
+
     # Construct GitHub link
-    "https://github.com/alphagov/govuk-frontend/tree/v#{govuk_frontend_version}/src/govuk/#{item.file.path}#L#{item.context.line.start}-L#{item.context.line.end}"
+    "https://github.com/alphagov/govuk-frontend/tree/v#{govuk_frontend_version}#{github_package_path}/govuk/#{item.file.path}#L#{item.context.line.start}-L#{item.context.line.end}"
   end
 
   def govuk_frontend_version

--- a/spec/sassdocs_helpers_spec.rb
+++ b/spec/sassdocs_helpers_spec.rb
@@ -11,7 +11,7 @@ end
 
 RSpec.describe SassdocsHelpers do
   before(:each) do
-    allow(File).to receive(:read).and_return('{ "packages": { "node_modules/govuk-frontend": { "version": "1.0.0" } } }')
+    allow(File).to receive(:read).and_return('{ "packages": { "node_modules/govuk-frontend": { "version": "5.0.0" } } }')
     # Include mixin into a test class to allow us to mock File
     # TODO Move constant definition
     # rubocop:disable Lint/ConstantDefinitionInBlock
@@ -337,14 +337,14 @@ RSpec.describe SassdocsHelpers do
       })
       url = @helper.github_url(fixture)
 
-      expect(url).to eq("https://github.com/alphagov/govuk-frontend/tree/v1.0.0/src/govuk/helpers/_clearfix.scss#L9-L15")
+      expect(url).to eq("https://github.com/alphagov/govuk-frontend/tree/v5.0.0/packages/govuk-frontend/src/govuk/helpers/_clearfix.scss#L9-L15")
     end
   end
   describe "#govuk_frontend_version" do
     it "returns version" do
       version = @helper.govuk_frontend_version
 
-      expect(version).to eq("1.0.0")
+      expect(version).to eq("5.0.0")
     end
   end
 end

--- a/spec/sassdocs_helpers_spec.rb
+++ b/spec/sassdocs_helpers_spec.rb
@@ -10,8 +10,11 @@ def dothash(hash)
 end
 
 RSpec.describe SassdocsHelpers do
+  let(:package_version) { "5.0.0" }
+  let(:package_content) { sprintf('{ "packages": { "node_modules/govuk-frontend": { "version": "%s" } } }', package_version) }
+
   before(:each) do
-    allow(File).to receive(:read).and_return('{ "packages": { "node_modules/govuk-frontend": { "version": "5.0.0" } } }')
+    allow(File).to receive(:read).and_return(package_content)
     # Include mixin into a test class to allow us to mock File
     # TODO Move constant definition
     # rubocop:disable Lint/ConstantDefinitionInBlock
@@ -323,8 +326,8 @@ RSpec.describe SassdocsHelpers do
     end
   end
   describe "#github_url" do
-    it "returns a url" do
-      fixture = dothash({
+    let(:fixture) do
+      dothash({
         context: {
           line: {
             start: 9,
@@ -335,9 +338,20 @@ RSpec.describe SassdocsHelpers do
           path: "helpers/_clearfix.scss",
         },
       })
-      url = @helper.github_url(fixture)
+    end
 
+    it "returns a url" do
+      url = @helper.github_url(fixture)
       expect(url).to eq("https://github.com/alphagov/govuk-frontend/tree/v5.0.0/packages/govuk-frontend/src/govuk/helpers/_clearfix.scss#L9-L15")
+    end
+
+    describe "v4.x backwards compatibility" do
+      let(:package_version) { "4.0.0" }
+
+      it "returns a url" do
+        url = @helper.github_url(fixture)
+        expect(url).to eq("https://github.com/alphagov/govuk-frontend/tree/v4.0.0/src/govuk/helpers/_clearfix.scss#L9-L15")
+      end
     end
   end
   describe "#govuk_frontend_version" do


### PR DESCRIPTION
This PR updates the GitHub URL helper for GOV.UK Frontend v5

For now, I've maintained backwards compatibility with v4