### PR TITLE
Correct node_modules folder name in index.html.md.erb

### DIFF
--- a/source/get-started/index.html.md.erb
+++ b/source/get-started/index.html.md.erb
@@ -70,7 +70,7 @@ In your live application, we recommend [using an automated task or your build pi
     <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
     ```
 
-2. Copy the `/node-modules/govuk-frontend/govuk/all.js` file to `<YOUR-JAVASCRIPT-FOLDER>/govuk.js`.
+2. Copy the `/node_modules/govuk-frontend/govuk/all.js` file to `<YOUR-JAVASCRIPT-FOLDER>/govuk.js`.
 
 3. Import the file before the closing `</body>` tag of your page template, then run the `initAll` function to initialise all the components. For example:
 


### PR DESCRIPTION
In point 2 of section "5. Get the JavaScript working" there was an incorrect reference to the node_modules folder which was typed as as node-modules (hyphen instead of underscore).

This change fixes that small issue.