### PR TITLE
Add explanation that individual initialisation will throw errors

### DIFF
--- a/source/importing-css-assets-and-javascript/index.html.md.erb
+++ b/source/importing-css-assets-and-javascript/index.html.md.erb
@@ -162,6 +162,16 @@ Then import the JavaScript file before the closing `</body>` tag of your HTML pa
 </body>
 ```
 
+Errors from components will be logged in the browser's console.
+
+For example, when:
+
+* GOV.UK Frontend is not supported in the current browser
+* Component templates have missing changes from our release notes
+* Component JavaScript configuration does not match our documentation
+
+You should check your application works without errors or some components will not work correctly.
+
 #### Select and initialise an individual component
 
 You can select and initialise a specific component by using its `data-module` attribute. For example, use `govuk-radios` to initialise the first radio component on a page:
@@ -175,6 +185,8 @@ You can select and initialise a specific component by using its `data-module` at
     }
   </script>
 ```
+
+When initialised individually, errors are thrown rather than logged. You must check your application works without errors or some components will not work correctly.
 
 ### Import JavaScript using a bundler
 


### PR DESCRIPTION
As we decided that to start with, [we’d limit our public API to “we throw errors”](https://github.com/alphagov/govuk-frontend/issues/4074#issuecomment-1731127591), we don’t have any specific errors to document as part of our [JavaScript API Reference](https://frontend.design-system.service.gov.uk/javascript-api-reference/). 

I think we don't need more than [an update to “Select and initialise individual components” (Netlify preview)](https://document-errors--govuk-frontend-docs-preview.netlify.app/importing-css-assets-and-javascript/#select-and-initialise-an-individual-component), which this PR adds.

Only other thing I could think of may be to discuss “Initialising components” to the JavaScript API Reference to explain that initAll doesn’t throw but logs and individual initialisation throws, but there’s a bit of overlap with the [JavaScript section of Import CSS, assets and JavaScript](https://document-errors--govuk-frontend-docs-preview.netlify.app/importing-css-assets-and-javascript/#javascript) that lists all the options for initialising already. Seems like this would be a wider piece of work around structuring how we organise the JavaScript API docs (especially to keep the component names in the menu).

Part of the work for #341 