### PR TITLE
Add new page describing our browser support strategy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4240,6 +4240,7 @@
       "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.0.0-internal.0.tgz",
       "integrity": "sha512-10Fi0npmyviowB/Q8xwtlYKJ6u4ZivjE8fLd8L9Yy2UypzZTl9J7MuD2Ur0RAhSSO6uRujLXyKhrsiR6UK/qFw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 4.2.0"
       },

--- a/source/browser-support/index.html.md.erb
+++ b/source/browser-support/index.html.md.erb
@@ -1,0 +1,66 @@
+---
+title: Browser support
+weight: 42
+---
+
+# Browser support
+
+To make sure the public can successfully access and use government services, regardless of the browser they're using, the Design System team has divided browsers into 4 grades. Each grade shows the level of support we will provide.
+
+You can see more information about [how we provide support for different browsers](https://github.com/alphagov/govuk-frontend/blob/main/docs/contributing/browser-support.md) in our GitHub documentation.
+
+## Grade A
+
+Grade A browsers include the most recent stable versions of Chrome, Firefox, Edge, Samsung Internet and Safari.
+
+These browsers should be able to parse GOV.UK Frontend's JavaScript without error. We aim to provide the same overall experience in Grade A and B browsers.
+
+When supporting these browsers we will:
+
+-   use Grade A browsers for any manual testing carried out during the development process
+-   use our automated test suites as standard
+-   treat bugs affecting Grade A browsers as high priority
+
+## Grade B
+
+Grade B browsers include all stable versions of Chrome, Firefox and Edge released in the last 6 months and the last 4 releases of Safari which are not supported in Grade A.
+
+These browsers should be able to parse GOV.UK Frontend's JavaScript without error. We aim to provide the same overall experience in Grade A and B browsers.
+
+When supporting these browsers we will:
+
+-   use our automated test suites as standard
+-   treat bugs affecting Grade B browsers as low priority unless they prevent a user from being able to complete their task
+
+## Grade C
+
+Grade C covers browsers not in Grade A or B which support `<script type="module">`. These are:
+
+-   Chrome 61+
+-   Edge 16-18
+-   Edge 79+
+-   Safari 11 (mac)
+-   Firefox 60+
+-   Opera 48+
+-   Safari 10.3+ (iOS)
+-   Samsung Internet 8.2+
+
+Safari 10.1 also supports `<script type="module">` but will 'exit early' as it does not support `HTMLScriptElement.prototype.noModule` which is how we test support for `<script type="module">` from within our JavaScript.
+
+These browsers should be able to parse GOV.UK Frontend's JavaScript without error. 
+
+However, we might disable or reduce features on an individual basis in browsers where the underlying features are not available. Exceptions will be if users need the feature to complete their task.
+
+For grade C browsers we:
+
+-   might remove support for individual features in these browsers at any time without considering them a breaking change
+-   will not regularly test in these browsers
+-   will not fix bugs affecting these browsers unless they prevent a user from being able to complete their task, or we can fix the bug by disabling a feature
+
+## Grade X
+
+Grade X includes all browsers that do not support `<script type="module">`, including all versions of Internet Explorer.
+
+These browsers should not download or attempt to parse GOV.UK Frontend's JavaScript.
+
+We will not regularly test in these browsers. We will not fix bugs affecting these browsers.


### PR DESCRIPTION
Adds the content of [the draft of our summary of our browser support strategy (internal link)](https://docs.google.com/document/d/10rkRaoPo_1nVw1hmYSSUKEttBKrY9OSM-6bI-5J5QJ4/edit) to the docs. 

Couldn't remember if/where we said we'd put it in the menu, so just appended it to the list. Please feel free to update the PR and put it at another level.

Part of #340 (the issue needs to wait for [the full guidance to have been merged on the `govuk-frontend` repo](https://github.com/alphagov/govuk-frontend/pull/4381) before being closed).