### PR TITLE
Prevent confusion from preview site linking to release site

### DIFF
--- a/source/changes-to-govuk-frontend-v5/index.html.md.erb
+++ b/source/changes-to-govuk-frontend-v5/index.html.md.erb
@@ -9,7 +9,7 @@ What you need to know about the changes to v5.0.0.
 
 ## Migrating from v4 to v5
 
-Follow the guidance about [staying up to date with GOV.UK Frontend](https://frontend.design-system.service.gov.uk/staying-up-to-date/).
+Follow the guidance about [staying up to date with GOV.UK Frontend](/staying-up-to-date/).
 
 When making the decision to migrate, consider your service’s current requirements. If you currently need to continue CSS support for legacy browsers like IE8, IE9, IE10, or need JavaScript support for IE11, you should not migrate to V5 at this time.
 

--- a/source/staying-up-to-date/index.html.md.erb
+++ b/source/staying-up-to-date/index.html.md.erb
@@ -126,6 +126,6 @@ npm install govuk-frontend@4.6.0
 
 ### Updating to the latest version if you installed GOV.UK Frontend using precompiled files
 
-Follow the [instructions for installing using precompiled files](https://frontend.design-system.service.gov.uk/install-using-precompiled-files/), replacing any files that already exist.
+Follow the [instructions for installing using precompiled files](/install-using-precompiled-files/), replacing any files that already exist.
 
 You should also remove older versions of the precompiled CSS and JavaScript, and any other files that no longer exist in the latest release.

--- a/source/v5-0-announcement/index.html.md.erb
+++ b/source/v5-0-announcement/index.html.md.erb
@@ -10,13 +10,13 @@ layout: core
 
 ## Summary
 
-If you’re responsible for a public-facing government service on GOV.UK, it will probably be built using [GOV.UK Frontend](https://frontend.design-system.service.gov.uk/).
+If you’re responsible for a public-facing government service on GOV.UK, it will probably be built using [GOV.UK Frontend](/).
 
 GOV.UK Frontend contains the code that gives a consistent look and feel to government services on GOV.UK. We’re modernising the code and removing support for legacy technologies and older web browsers, which will have an impact on your digital teams. We estimate updating to the latest version could take 1–2 weeks to implement, depending on how your teams currently use GOV.UK Frontend. Based on current estimates, it will be available between October and December 2023.
 
 ## What is GOV.UK Frontend?
 
-If you’re responsible for a public-facing government service on GOV.UK, it will likely be built using [GOV.UK Frontend](https://frontend.design-system.service.gov.uk/).
+If you’re responsible for a public-facing government service on GOV.UK, it will likely be built using [GOV.UK Frontend](/).
 
 GOV.UK Frontend contains the code you need to start building a user interface for government platforms and services. It’s part of the GOV.UK Design System which gives a consistent look and feel to government services on GOV.UK.
 


### PR DESCRIPTION
When browsing the [v5 preview site](https://release-5-0--govuk-frontend-docs-preview.netlify.app), some links sneakily direct users to the [v4 release site](https://frontend.design-system.service.gov.uk)