### PR TITLE
Allow Node.js LTS ‘Iron’ (v20) release version

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,6 +23,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           cache: npm
+          check-latest: true
           node-version-file: .nvmrc
 
       - uses: ruby/setup-ruby@v1

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/hydrogen
+lts/iron

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,10 @@
         "sassdoc": "^2.7.4",
         "standard": "^17.1.0",
         "tap-mocha-reporter": "^5.0.4"
+      },
+      "engines": {
+        "node": "^20.9.0",
+        "npm": "^10.1.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -14,5 +14,9 @@
     "sassdoc": "^2.7.4",
     "standard": "^17.1.0",
     "tap-mocha-reporter": "^5.0.4"
+  },
+  "engines": {
+    "node": "^20.9.0",
+    "npm": "^10.1.0"
   }
 }


### PR DESCRIPTION
This PR allows Node.js LTS ‘Iron’ (v20) to install dependencies for **GOV.UK Frontend Docs**

>GOV.UK Frontend requires Node.js version 12.17.0 or later to support ECMAScript modules. Where possible, we recommend you install the latest Long Term Support (LTS) version.

Changes included:

1. **Updating [.nvmrc](https://github.com/alphagov/govuk-frontend/blob/main/.nvmrc)** for Node.js 20
So tools like [nvm](https://github.com/nvm-sh/nvm#readme) and [asdf](https://github.com/asdf-vm/asdf#readme) allow the `lts/iron` LTS release

3. **Add the [package.json `engines.node` range](https://github.com/alphagov/govuk-frontend/blob/main/package.json#L6)**
Ensures `npm install` and other scripts check the local Node.js version is allowed

3. **Add the [package.json `engines.npm` range](https://github.com/alphagov/govuk-frontend/blob/main/package.json#L7)**
Ensure support for `npm@10` rather than `npm@9`