### PR TITLE
Proxy requests for security.txt

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,9 @@
+[[redirects]]
+  from = "/.well-known/security.txt"
+  to = "https://vdp.cabinetoffice.gov.uk/.well-known/security.txt"
+  status = 200 # Proxy rather than redirect
+
+[[redirects]]
+  from = "/security.txt"
+  to = "https://vdp.cabinetoffice.gov.uk/.well-known/security.txt"
+  status = 200 # Proxy rather than redirect


### PR DESCRIPTION
Adds Netlify configuration for proxying requests to `/security.txt` and `/.well-known/security.txt`. Our current site doesn't have those, but it'll make Frontend Docs do the same as Design System on that front.

Closes #382 as [the Frontend Docs NGINX configuration](https://github.com/alphagov/govuk-frontend-docs/blob/main/deploy/nginx.conf) has no redirects.