### PR TITLE
Organise JavaScript configuration documentation

### DIFF
--- a/source/configure-components-with-javascript/index.html.md.erb
+++ b/source/configure-components-with-javascript/index.html.md.erb
@@ -10,9 +10,9 @@ You can configure some of the components in GOV.UK Frontend to customise their b
 You can configure a component by:
 
 - setting Nunjucks macro options
-- using data attributes in the HTML
 - passing a JavaScript object when creating an instance of a component
 - using the `initAll` function
+- using data attributes in the HTML
 
 Read the [JavaScript API Reference](../javascript-api-reference/) for the configuration accepted by each component and any errors that might be thrown during initialisation.
 
@@ -21,36 +21,6 @@ The examples below follow our recommended [Import JavaScript using a bundler](..
 ## Setting Nunjucks macro options
 
 If you're using the Nunjucks macros, you can read about [configuring a component](../use-nunjucks/#configuring-a-component) or find all of the configuration options published on the [GOV.UK Design System website](https://design-system.service.gov.uk/).
-
-## Passing configuration using data attributes in HTML
-
-If you're using HTML, you can pass configuration by adding data attributes to the component's outermost element (the element that has the `data-module` attribute). This is how our Nunjucks macros forward the configuration to the JavaScript components in the browser. Data attributes use kebab-case.
-
-Some configuration options are grouped under a namespace to keep related options together. For example, [the localisation options](../localise-govuk-frontend/) are grouped under the `i18n` namespace. When using these options, include the namespace as a prefix followed by a period as part of the attribute name.
-
-For options accepting object values, you'll need to set one attribute for each key of that object. Suffix the attribute name (including any namespace) with a period and the name of the key in the object.
-
-This example shows the opening tag of a character count component with some configuration options including:
-
-- a specific number of characters (non-namespaced configuration)
-- a new message for when users reach the specified number of characters (namespaced configuration)
-- two plural forms for when users are under the specified limit of characters (namespaced configuration + object value)
-
-```html
-<div
-  data-module="govuk-character-count"
-  data-maxlength="500"
-  data-i18n.characters-at-limit="No characters left"
-  data-i18n.characters-under-limit.other="%{count} characters to go"
-  data-i18n.characters-under-limit.one="%{count} character to go"
->
-```
-
-If your configuration contains [quotes or other reserved HTML characters](https://developer.mozilla.org/en-US/docs/Glossary/Entity#reserved_characters), you'll need to escape those characters.
-
-Configuration is read from data attributes when the component is initialised. Changes to the data attributes made after the component has been initialised will have no effect on the behaviour of the component.
-
-You'll need to convert the [JavaScript API Reference](../javascript-api-reference/) configuration options into kebab-case when using data attributes in HTML.
 
 ## Passing configuration to a new instance of a component in JavaScript
 
@@ -110,3 +80,33 @@ initAll({
 ```
 
 Read the [JavaScript API Reference](../javascript-api-reference/) for the configuration accepted by `initAll`.
+
+## Passing configuration using data attributes in HTML
+
+If you're using HTML, you can pass configuration by adding data attributes to the component's outermost element (the element that has the `data-module` attribute). This is how our Nunjucks macros forward the configuration to the JavaScript components in the browser. Data attributes use kebab-case.
+
+Some configuration options are grouped under a namespace to keep related options together. For example, [the localisation options](../localise-govuk-frontend/) are grouped under the `i18n` namespace. When using these options, include the namespace as a prefix followed by a period as part of the attribute name.
+
+For options accepting object values, you'll need to set one attribute for each key of that object. Suffix the attribute name (including any namespace) with a period and the name of the key in the object.
+
+This example shows the opening tag of a character count component with some configuration options including:
+
+- a specific number of characters (non-namespaced configuration)
+- a new message for when users reach the specified number of characters (namespaced configuration)
+- two plural forms for when users are under the specified limit of characters (namespaced configuration + object value)
+
+```html
+<div
+  data-module="govuk-character-count"
+  data-maxlength="500"
+  data-i18n.characters-at-limit="No characters left"
+  data-i18n.characters-under-limit.other="%{count} characters to go"
+  data-i18n.characters-under-limit.one="%{count} character to go"
+>
+```
+
+If your configuration contains [quotes or other reserved HTML characters](https://developer.mozilla.org/en-US/docs/Glossary/Entity#reserved_characters), you'll need to escape those characters.
+
+Configuration is read from data attributes when the component is initialised. Changes to the data attributes made after the component has been initialised will have no effect on the behaviour of the component.
+
+You'll need to convert the [JavaScript API Reference](../javascript-api-reference/) configuration options into kebab-case when using data attributes in HTML.

--- a/source/configure-components-with-javascript/index.html.md.erb
+++ b/source/configure-components-with-javascript/index.html.md.erb
@@ -9,20 +9,21 @@ You can configure some of the components in GOV.UK Frontend to customise their b
 
 You can configure a component by:
 
-- setting Nunjucks macro options
-- passing a JavaScript object when creating an instance of a component
-- using the `initAll` function
-- using data attributes in the HTML
-
-Read the [JavaScript API Reference](../javascript-api-reference/) for the configuration accepted by each component and any errors that might be thrown during initialisation.
-
-The examples below follow our recommended [Import JavaScript using a bundler](../importing-css-assets-and-javascript/#import-javascript-using-a-bundler) approach.
+- [setting Nunjucks macro options](#setting-nunjucks-macro-options)
+- [passing JavaScript configuration](#passing-javascript-configuration)
+- [adding HTML data attributes](#adding-html-data-attributes)
 
 ## Setting Nunjucks macro options
 
 If you're using the Nunjucks macros, you can read about [configuring a component](../use-nunjucks/#configuring-a-component) or find all of the configuration options published on the [GOV.UK Design System website](https://design-system.service.gov.uk/).
 
-## Passing configuration to a new instance of a component in JavaScript
+## Passing JavaScript configuration
+
+Read the [JavaScript API Reference](../javascript-api-reference/) for the configuration accepted by each component.
+
+The examples below follow our recommended [Import JavaScript using a bundler](../importing-css-assets-and-javascript/#import-javascript-using-a-bundler) approach.
+
+### Configure individual component instances
 
 You can pass a configuration object to the constructor when creating an instance of a component in JavaScript.
 
@@ -59,7 +60,7 @@ new CharacterCount($element, {
 
 Read the [JavaScript API Reference](../javascript-api-reference/) for the configuration accepted by each component.
 
-## Passing configuration using the initAll function
+### Configure all components using the initAll function
 
 You can pass configuration for components when initialising GOV.UK Frontend using the `initAll` function. You can do this by including key-value pairs of camel-cased component names and configuration objects. This is the same method you would use to pass them when creating an instance of the component. For example:
 
@@ -81,7 +82,7 @@ initAll({
 
 Read the [JavaScript API Reference](../javascript-api-reference/) for the configuration accepted by `initAll`.
 
-## Passing configuration using data attributes in HTML
+## Adding HTML data attributes
 
 If you're using HTML, you can pass configuration by adding data attributes to the component's outermost element (the element that has the `data-module` attribute). This is how our Nunjucks macros forward the configuration to the JavaScript components in the browser. Data attributes use kebab-case.
 

--- a/source/configure-components-with-javascript/index.html.md.erb
+++ b/source/configure-components-with-javascript/index.html.md.erb
@@ -21,7 +21,10 @@ If you're using the Nunjucks macros, you can read about [configuring a component
 
 Read the [JavaScript API Reference](../javascript-api-reference/) for the configuration accepted by each component.
 
-The examples below follow our recommended [Import JavaScript using a bundler](../importing-css-assets-and-javascript/#import-javascript-using-a-bundler) approach.
+The examples below follow our recommended [Import JavaScript using a bundler](../importing-css-assets-and-javascript/#import-javascript-using-a-bundler) approach and demonstrate how to:
+
+- [configure individual component instances](#configure-individual-component-instances)
+- [configure all components using the initAll function](#configure-all-components-using-the-initall-function)
 
 ### Configure individual component instances
 

--- a/source/configure-components-with-javascript/index.html.md.erb
+++ b/source/configure-components-with-javascript/index.html.md.erb
@@ -14,6 +14,8 @@ You can configure a component by:
 - passing a JavaScript object when creating an instance of a component
 - using the `initAll` function
 
+The examples below follow our recommended [Import JavaScript using a bundler](../importing-css-assets-and-javascript/#import-javascript-using-a-bundler) approach.
+
 ## Setting Nunjucks macro options
 
 If you're using the Nunjucks macros, you will find all of the configuration options for a component published on the GOV.UK Design System website.
@@ -66,6 +68,8 @@ Components will merge the configuration provided at initialisation with those pr
 Some configuration options might accept object values or be grouped under a namespace to keep related things together. For example, [the localisation options](../localise-govuk-frontend/) are grouped under the `i18n` namespace. When using these options, use nested objects. For example:
 
 ```javascript
+import { CharacterCount } from 'govuk-frontend'
+
 new CharacterCount($element, {
   // Non namespaced
   maxlength: 500,
@@ -90,6 +94,8 @@ Read the [JavaScript API Reference](../javascript-api-reference/) to see what co
 You can pass configuration for components when initialising GOV.UK Frontend using the `initAll` function. You can do this by including key-value pairs of camel-cased component names and configuration objects. This is the same method you would use to pass them when creating an instance of the component. For example:
 
 ```javascript
+import { initAll } from 'govuk-frontend'
+
 initAll({
   characterCount: {
     // Non namespaced

--- a/source/configure-components-with-javascript/index.html.md.erb
+++ b/source/configure-components-with-javascript/index.html.md.erb
@@ -14,6 +14,8 @@ You can configure a component by:
 - passing a JavaScript object when creating an instance of a component
 - using the `initAll` function
 
+Read the [JavaScript API Reference](../javascript-api-reference/) for the configuration accepted by each component and any errors that might be thrown during initialisation.
+
 The examples below follow our recommended [Import JavaScript using a bundler](../importing-css-assets-and-javascript/#import-javascript-using-a-bundler) approach.
 
 ## Setting Nunjucks macro options
@@ -50,7 +52,7 @@ If your configuration contains [quotes or other reserved HTML characters](https:
 
 Configuration is read from data attributes when the component is initialised. Changes to the data attributes made after the component has been initialised will have no effect on the behaviour of the component.
 
-Read the [JavaScript API Reference](../javascript-api-reference/) for the configuration accepted by each component. You'll need to convert the configuration names into kebab-case.
+You'll need to convert the [JavaScript API Reference](../javascript-api-reference/) configuration options into kebab-case when using data attributes in HTML.
 
 ## Passing configuration to a new instance of a component in JavaScript
 
@@ -87,7 +89,7 @@ new CharacterCount($element, {
 })
 ```
 
-Read the [JavaScript API Reference](../javascript-api-reference/) to see what configuration each component accepts.
+Read the [JavaScript API Reference](../javascript-api-reference/) for the configuration accepted by each component.
 
 ## Passing configuration using the initAll function
 
@@ -108,3 +110,5 @@ initAll({
   }
 })
 ```
+
+Read the [JavaScript API Reference](../javascript-api-reference/) for the configuration accepted by `initAll`.

--- a/source/configure-components-with-javascript/index.html.md.erb
+++ b/source/configure-components-with-javascript/index.html.md.erb
@@ -20,9 +20,7 @@ The examples below follow our recommended [Import JavaScript using a bundler](..
 
 ## Setting Nunjucks macro options
 
-If you're using the Nunjucks macros, you will find all of the configuration options for a component published on the GOV.UK Design System website.
-
-You can find the Nunjucks macro options by selecting the Nunjucks tab in the example box and selecting the Nunjucks macro options.
+If you're using the Nunjucks macros, you can read about [configuring a component](../use-nunjucks/#configuring-a-component) or find all of the configuration options published on the [GOV.UK Design System website](https://design-system.service.gov.uk/).
 
 ## Passing configuration using data attributes in HTML
 

--- a/source/configure-components/index.html.md.erb
+++ b/source/configure-components/index.html.md.erb
@@ -25,6 +25,7 @@ The examples below follow our recommended [Import JavaScript using a bundler](..
 
 - [configure individual component instances](#configure-individual-component-instances)
 - [configure all components using the initAll function](#configure-all-components-using-the-initall-function)
+- [check for JavaScript errors in the browser console](#javascript-errors-in-the-browser-console)
 
 ### Configure individual component instances
 
@@ -84,6 +85,18 @@ initAll({
 ```
 
 Read the [JavaScript API Reference](../javascript-api-reference/) for the configuration accepted by `initAll`.
+
+### JavaScript errors in the browser console
+
+Errors from components will be logged in the browser's console.
+
+For example, when:
+
+* GOV.UK Frontend is not supported in the current browser
+* Component templates have missing changes from our release notes
+* Component JavaScript configuration does not match our documentation
+
+You should check your application works without errors or some components will not work correctly.
 
 ## Adding HTML data attributes
 

--- a/source/configure-components/index.html.md.erb
+++ b/source/configure-components/index.html.md.erb
@@ -1,9 +1,9 @@
 ---
-title: Configure components with JavaScript
+title: Configure components
 weight: 76
 ---
 
-# Configure components with JavaScript
+# Configure components
 
 You can configure some of the components in GOV.UK Frontend to customise their behaviour or to [localise their JavaScript to use a language other than English](../localise-govuk-frontend/).
 

--- a/source/configure-components/index.html.md.erb
+++ b/source/configure-components/index.html.md.erb
@@ -96,6 +96,12 @@ For example, when:
 * Component templates have missing changes from our release notes
 * Component JavaScript configuration does not match our documentation
 
+If the HTML snippet from [Import CSS, assets and JavaScript](../importing-css-assets-and-javascript/#before-you-start) was not added to the top of the `<body class="govuk-template__body">` section you'll see this error:
+
+```
+SupportError: GOV.UK Frontend initialised without `<body class="govuk-frontend-supported">` from template `<script>` snippet
+```
+
 You should check your application works without errors or some components will not work correctly.
 
 ## Adding HTML data attributes

--- a/source/importing-css-assets-and-javascript/index.html.md.erb
+++ b/source/importing-css-assets-and-javascript/index.html.md.erb
@@ -202,15 +202,7 @@ Then import the JavaScript file before the closing `</body>` tag of your HTML pa
 </body>
 ```
 
-Errors from components will be logged in the browser's console.
-
-For example, when:
-
-* GOV.UK Frontend is not supported in the current browser
-* Component templates have missing changes from our release notes
-* Component JavaScript configuration does not match our documentation
-
-You should check your application works without errors or some components will not work correctly.
+Read about how we log [JavaScript errors in the browser console](../configure-components/#javascript-errors-in-the-browser-console) to check GOV.UK Frontend has been set up correctly.
 
 #### Select and initialise an individual component
 

--- a/source/javascript-api-reference/index.html.md.erb
+++ b/source/javascript-api-reference/index.html.md.erb
@@ -8,7 +8,7 @@ weight: 80
 Some of our components can receive configuration options when you create an
 instance in JavaScript. This page lists the available options for these
 components. You can find further information on how to [configure these options
-in our guidance](../configure-components-with-javascript/).
+in our guidance](../configure-components/).
 
 You can pass these options in an object either as:
 

--- a/source/javascript-api-reference/index.html.md.erb
+++ b/source/javascript-api-reference/index.html.md.erb
@@ -18,7 +18,7 @@ You can pass these options in an object either as:
 For example, to set the `preventDoubleClick` option of a button:
 
 ```javascript
-import { Button, initAll } from '<YOUR-APP>/govuk-frontend.min.js'
+import { Button, initAll } from 'govuk-frontend'
 
 // Creating a single instance
 const $button = document.querySelector('[data-module="button"]')

--- a/source/localise-govuk-frontend/index.html.md.erb
+++ b/source/localise-govuk-frontend/index.html.md.erb
@@ -37,7 +37,7 @@ If you're using the Nunjucks macro, look at the Nunjucks macro options table in 
 
 If you're using the HTML directly, you can customise the text used in the JavaScript by passing configuration using data attributes.
 
-Alternatively, you can [configure the component with JavaScript](../configure-components-with-javascript/) at the point you initialise it or when using `initAll`.
+Alternatively, you can [configure the component with JavaScript](../configure-components/) at the point you initialise it or when using `initAll`.
 
 The naming conventions for:
 
@@ -92,7 +92,7 @@ If you're looking to keep English messages and override only one of the plural f
 
 Our components will replace the `%{count}` placeholder with the number used for picking the plural category.
 
-The following example shows how to provide pluralisation options using the different ways you can [configure components with JavaScript](../configure-components-with-javascript/):
+The following example shows how to provide pluralisation options using the different ways you can [configure components with JavaScript](../configure-components/):
 
 With Nunjucks
 

--- a/source/use-nunjucks/index.html.md.erb
+++ b/source/use-nunjucks/index.html.md.erb
@@ -49,7 +49,7 @@ Find out how to [change how the page template works](https://design-system.servi
 
 ## Adding a component
 
-Go to any component page on the Design System website, then copy the Nunjucks macro code from the **Nunjucks** tab of any example.
+Go to [any component page](https://design-system.service.gov.uk/components/) on the Design System website, then copy the Nunjucks macro code from the **Nunjucks** tab of any example.
 
 For example, to add the breadcrumbs component to your page, copy the code from the **Nunjucks** tab in the first example on the [breadcrumbs component page](https://design-system.service.gov.uk/components/breadcrumbs/).
 
@@ -65,6 +65,6 @@ For example, use the `text` option to change the text on a [button](https://desi
 }) }}
 ```
 
-To see the options for a component, select the **Nunjucks** tab of the component example on any Design System website page, then select **Nunjucks macro options**.
+To see the options for a component, go to [any component page](https://design-system.service.gov.uk/components/) on the Design System website, select the **Nunjucks** tab of an example, then select **Nunjucks macro options**.
 
 You must sanitise any HTML you pass in to Nunjucks macros you’re using in your live application to protect your website against cross-site scripting (XSS) attacks. You can read more about [XSS](https://developer.mozilla.org/en-US/docs/Web/Security/Types_of_attacks#Cross-site_scripting_XSS) on the MDN website.

--- a/source/use-nunjucks/index.html.md.erb
+++ b/source/use-nunjucks/index.html.md.erb
@@ -53,11 +53,11 @@ Go to [any component page](https://design-system.service.gov.uk/components/) on 
 
 For example, to add the breadcrumbs component to your page, copy the code from the **Nunjucks** tab in the first example on the [breadcrumbs component page](https://design-system.service.gov.uk/components/breadcrumbs/).
 
-## Changing a component
+## Configuring a component
 
-You can use options to change how a component looks or behaves.
+You can use options to configure how a component looks or behaves.
 
-For example, use the `text` option to change the text on a [button](https://design-system.service.gov.uk/components/button/):
+For example, use the `text` option to configure the text on a [button](https://design-system.service.gov.uk/components/button/):
 
 ```javascript
 {{ govukButton({


### PR DESCRIPTION
We have lots of JavaScript examples split across:

* [**Import CSS, assets and JavaScript**](https://release-5-0--govuk-frontend-docs-preview.netlify.app/importing-css-assets-and-javascript/)
* [**Configure components with JavaScript**](https://release-5-0--govuk-frontend-docs-preview.netlify.app/configure-components-with-javascript/)

This makes it difficult to add information about:

1. Errors in the browser console
2. Different flavours of JavaScript
3. Benefits of using a bundler

It's hard to document ways to import JavaScript when the "importing" page is full of configuration examples

## Configuration shuffle

This PR adds a new [**Configure components** page](https://deploy-preview-395--govuk-frontend-docs-preview.netlify.app/configure-components/)

It was previously called **Configure components with JavaScript** but we now have three clear sections for:

* [Setting Nunjucks macro options](https://deploy-preview-395--govuk-frontend-docs-preview.netlify.app/configure-components/#setting-nunjucks-macro-options)
* [Passing JavaScript configuration](https://deploy-preview-395--govuk-frontend-docs-preview.netlify.app/configure-components/#passing-javascript-configuration)
* [Adding HTML data attributes](https://deploy-preview-395--govuk-frontend-docs-preview.netlify.app/configure-components/#adding-html-data-attributes)

Where the **Passing JavaScript configuration** section is split further into:

* [Configure individual component instances](https://deploy-preview-395--govuk-frontend-docs-preview.netlify.app/configure-components/#configure-individual-component-instances)
* [Configure all components using the initAll function](https://deploy-preview-395--govuk-frontend-docs-preview.netlify.app/configure-components/#configure-all-components-using-the-initall-function)
* [JavaScript errors in the browser console](https://deploy-preview-395--govuk-frontend-docs-preview.netlify.app/configure-components/#javascript-errors-in-the-browser-console)

In the next PR I'd like to move lots of [**Import CSS, assets and JavaScript**](https://deploy-preview-395--govuk-frontend-docs-preview.netlify.app/importing-css-assets-and-javascript/) JavaScript examples to this new page since they're related to configuration rather than importing

This gives us more freedom to use the **Import CSS, assets and JavaScript** for different import flavours