### PR TITLE
Configure components redirect

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -7,3 +7,8 @@
   from = "/security.txt"
   to = "https://vdp.cabinetoffice.gov.uk/.well-known/security.txt"
   status = 200 # Proxy rather than redirect
+
+[[redirects]]
+  from = "/configure-components-with-javascript/"
+  to = "/configure-components/"
+  status = 301


### PR DESCRIPTION
Redirects the 'Configure components' page, previously at `/configure-components-with-javascript/` ([link to preview site with the old path](https://deploy-preview-401--govuk-frontend-docs-preview.netlify.app/configure-components-with-javascript/)) to its new location `/configure-components/`.