### PR TITLE
Fix missing double quote in `$radios` selector

### DIFF
--- a/source/importing-css-assets-and-javascript/index.html.md.erb
+++ b/source/importing-css-assets-and-javascript/index.html.md.erb
@@ -234,7 +234,7 @@ When using a component more than once, the same `import` can be initialised agai
 ```javascript
 import { Radios } from 'govuk-frontend'
 
-const $radios = document.querySelectorAll('[data-module="govuk-radios]')
+const $radios = document.querySelectorAll('[data-module="govuk-radios"]')
 $radios.forEach(($radio) => {
   new Radios($radio)
 })

--- a/source/v4/importing-css-assets-and-javascript/index.html.md.erb
+++ b/source/v4/importing-css-assets-and-javascript/index.html.md.erb
@@ -190,7 +190,7 @@ if ($skipLink) {
   new SkipLink($skipLink).init()
 }
 
-var $radios = document.querySelectorAll('[data-module="govuk-radios]')
+var $radios = document.querySelectorAll('[data-module="govuk-radios"]')
 if ($radios) {
   for (var i = 0; i < $radios.length; i++) {
     new Radios($radios[i]).init()


### PR DESCRIPTION
Just spotted an [old typo](https://github.com/alphagov/govuk-frontend-docs/commit/fc9904f53dcb8fe01b7d6fd74cf265bd2a7670d1) in one of our example selectors