### PR TITLE
Add instructions for updating to a tagged version of the package

### DIFF
--- a/source/staying-up-to-date/index.html.md.erb
+++ b/source/staying-up-to-date/index.html.md.erb
@@ -124,6 +124,18 @@ If you want to install an earlier version, replace latest with the version that 
 npm install govuk-frontend@4.6.0
 ```
 
+If you want to install the most recent version of GOV.UK Frontend v4.x, run:
+
+```console
+npm install govuk-frontend@latest-v4
+```
+
+If you want to install the most recent pre-release, run:
+
+```console
+npm install govuk-frontend@next
+```
+
 ### Updating to the latest version if you installed GOV.UK Frontend using precompiled files
 
 Follow the [instructions for installing using precompiled files](/install-using-precompiled-files/), replacing any files that already exist.


### PR DESCRIPTION
This should help users install pre-releases, as well as the latest v4 version.

Closes alphagov/govuk-frontend#4476