### PR TITLE
Fix Markdown parameter rendering due to empty line after row

### DIFF
--- a/source/sass-api-reference/index.html.md.erb
+++ b/source/sass-api-reference/index.html.md.erb
@@ -27,7 +27,6 @@ weight: 90
 | ---- | ----------- | ---- | ------------- |
 <% parameters_table(item.parameter).each do |param| %>
 | # <%= param.name %> | <%= param.description %> | <%= param.type %> | <%= param.default_value %> |
-
 <% end %>
 <% end %>
 


### PR DESCRIPTION
This issue prevented tables with multiple rows from rendering correctly

It was caused by `prettier --write` when run on Markdown files in https://github.com/alphagov/govuk-frontend-docs/commit/df2fe5e4b9fc7aa306ad2595a7e75c0f914931c9

<img width="738" alt="Screenshot showing broken table row rendering beyond the first row" src="https://github.com/alphagov/govuk-frontend-docs/assets/415517/05491004-f0ff-4d02-a69e-5f0128d7c00f">

## Sass API reference
The rendering issue was not present in the [v4.x documentation](https://frontend.design-system.service.gov.uk/v4/) as shown:

* [**Spacing** mixin `govuk-responsive-margin` on v4.x](https://frontend.design-system.service.gov.uk/sass-api-reference/#govuk-responsive-margin)
* [**Spacing**  mixin `govuk-responsive-margin` on v5.x](https://frontend.design-system.service.gov.uk/sass-api-reference/#govuk-responsive-margin) – broken on `main`
* [**Spacing**  mixin `govuk-responsive-margin` on v5.x](https://deploy-preview-418--govuk-frontend-docs-preview.netlify.app/sass-api-reference/#govuk-responsive-margin) – fixed in this PR