### PR TITLE
Add note about adapting commands when updating GOV.UK Frontend for monorepos

### DIFF
--- a/source/staying-up-to-date/index.html.md.erb
+++ b/source/staying-up-to-date/index.html.md.erb
@@ -112,6 +112,11 @@ You might want to consider using automated testing or visual regression tests to
 
 ### Updating to the latest version if you installed GOV.UK Frontend using npm
 
+<p class="govuk-inset-text">
+  If you need to update GOV.UK Frontend for a specific package in a monorepo project (for example using Lerna, npm workspaces, Yarn workspaces, or pnpm workspaces),
+  please make sure to adapt the commands to the tool you are using.
+</p>
+
 To update to the most recent version, run:
 
 ```console


### PR DESCRIPTION
Projects using a monorepo to group multiple packages in a single repository will likely have `govuk-frontend` as a dependency of one of the repository's packages rather than at the root of their repository.

If they'd use the commands we provide as is, they'd end up installing `govuk-frontend` in the root `package.json`, while the one in the package actually using `govuk-frontend` remains in their old version. This means the project wouldn't effectively be upgraded.

There are many tools to manage a monorepo, evolving at their own pace. I don't think its our responsibility to provide the exact command to use for each of them, however I think adding a little warning would save people some headaches.

A couple of toughts behind the choices:
- Inset text helps grab the attention a little, in a slightly more subtle way than Warning text
- No note on the `installing-with-npm` page as it could be a valid decision to install `govuk-frontend` at the root of your monorepo, depending how you manage your repository.