### PR TITLE
Update 'Import JavaScript' page to use new `createAll` function

### DIFF
--- a/source/configure-components/index.html.md.erb
+++ b/source/configure-components/index.html.md.erb
@@ -13,7 +13,7 @@ You can configure a component by:
 - [passing JavaScript configuration](#passing-javascript-configuration)
 - [adding HTML data attributes](#adding-html-data-attributes)
 
-Configuration passed via data attributes in the HTML or via Nunjucks macro options will take precedence over any JavaScript configuration.
+Configuration passed through data attributes in the HTML or Nunjucks macro options will take precedence over any JavaScript configuration.
 
 To learn more about how configuration is passed from Nunjucks macros to HTML data attributes, see advanced examples in [the localisation options](../localise-govuk-frontend/).
 
@@ -72,22 +72,6 @@ initAll({
   }
 })
 ```
-
-#### Initialise only part of a page
-
-If you update a page with new markup, for example a modal dialogue box, you can run `initAll` with a `scope` parameter to initialise the components on part of a page:
-
-```javascript
-import { initAll } from 'govuk-frontend'
-
-const $element = document.querySelector('.app-modal')
-
-if ($element) {
-  initAll({ scope: $element })
-}
-```
-
-Read the [JavaScript API Reference](../javascript-api-reference/) for the list of components in the `initAll` configuration.
 
 ### JavaScript errors in the browser console
 

--- a/source/configure-components/index.html.md.erb
+++ b/source/configure-components/index.html.md.erb
@@ -13,6 +13,10 @@ You can configure a component by:
 - [passing JavaScript configuration](#passing-javascript-configuration)
 - [adding HTML data attributes](#adding-html-data-attributes)
 
+Configuration passed via data attributes in the HTML or via Nunjucks macro options will take precedence over any JavaScript configuration.
+
+To learn more about how configuration is passed from Nunjucks macros to HTML data attributes, see advanced examples in [the localisation options](../localise-govuk-frontend/).
+
 ## Setting Nunjucks macro options
 
 If you're using the Nunjucks macros, you can read about [configuring a component](../use-nunjucks/#configuring-a-component) or find all of the configuration options published on the [GOV.UK Design System website](https://design-system.service.gov.uk/).
@@ -23,44 +27,18 @@ Read the [JavaScript API Reference](../javascript-api-reference/) for the list o
 
 The examples below follow our recommended [Import JavaScript using a bundler](../import-javascript/#import-javascript-using-a-bundler) approach and demonstrate how to:
 
-- [configure individual component instances](#configure-individual-component-instances)
-- [configure all components using the initAll function](#configure-all-components-using-the-initall-function)
+- [configure instances of specific components using the `createAll` function](#configure-instances-of-specific-components-using-the-createall-function)
+- [configure all components using the `initAll` function](#configure-all-components-using-the-initall-function)
 - [check for JavaScript errors in the browser console](#javascript-errors-in-the-browser-console)
 
-### Configure individual component instances
+### Configure instances of specific components using the `createAll` function
 
-Component constructors accept two arguments:
-
-1. The HTML element that represents the component.
-2. An optional configuration object.
-
-Although JavaScript configuration objects are optional, configuration can still be provided or overridden by [HTML data attributes](#adding-html-data-attributes).
-
-To learn more about how configuration is passed from Nunjucks macros to HTML data attributes, see advanced examples in [the localisation options](../localise-govuk-frontend/).
-
-#### Without configuration object
-
-You can select and initialise a component using its `data-module` attribute. For example, use `govuk-character-count` to initialise the first character count component on a page:
+You can pass a configuration object into `createAll`'s second argument when creating an instance of a component in JavaScript:
 
 ```javascript
-import { CharacterCount } from 'govuk-frontend'
+import { CharacterCount, createAll } from 'govuk-frontend'
 
-const $element = document.querySelector('[data-module="govuk-character-count"]')
-new CharacterCount($element)
-```
-
-When initialised individually, errors are thrown rather than logged. You must check your application works without errors or some components will not work correctly.
-
-#### With configuration object
-
-You can pass a configuration object into the constructor's second argument when creating an instance of a component in JavaScript:
-
-```javascript
-import { CharacterCount } from 'govuk-frontend'
-
-const $element = document.querySelector('[data-module="govuk-character-count"]')
-
-new CharacterCount($element, {
+createAll(CharacterCount, {
   maxlength: 500,
   i18n: {
     charactersAtLimit: 'No characters left',

--- a/source/import-javascript/index.html.md.erb
+++ b/source/import-javascript/index.html.md.erb
@@ -101,6 +101,40 @@ import { initAll } from 'govuk-frontend'
 initAll()
 ```
 
+## Initialise only part of a page
+
+If you update a page with new markup, for example a modal dialogue box, you can 
+initialise components on that part of the page only.
+
+### Initialise individual components on part of a page
+
+Pass the scope into `createAll`'s third argument to initialise individual components:
+
+```javascript
+import { SkipLink, CharacterCount, createAll } from 'govuk-frontend'
+
+const $element = document.querySelector('.app-modal')
+
+// Use `undefined` as second arguments for components 
+// that don't need a config
+createAll(SkipLink, undefined, $element)
+createAll(CharacterCount, { maxLength: 500 }, $element)
+```
+
+### Initialise all components on part of a page
+
+Run `initAll` with a `scope` parameter to initialise the components on part of a page:
+
+```javascript
+import { initAll } from 'govuk-frontend'
+
+const $element = document.querySelector('.app-modal')
+
+if ($element) {
+  initAll({ scope: $element })
+}
+```
+
 ## Import JavaScript using alternative module formats
 
 ### Universal Module Definition (UMD)

--- a/source/import-javascript/index.html.md.erb
+++ b/source/import-javascript/index.html.md.erb
@@ -65,23 +65,30 @@ If your service cannot use ES modules, read about [alternative module formats](#
 
 ### Import individual components
 
-If you want to improve how quickly your service’s pages load in browsers, you can import only the JavaScript components you need.
+To improve how quickly your service’s pages load in browsers, import only the JavaScript components you need. You can also [configure each component](../configure-components/#passing-javascript-configuration) when instantiating them.
 
 ```javascript
-import { SkipLink, Radios } from 'govuk-frontend'
+import { SkipLink, CharacterCount, createAll } from 'govuk-frontend'
 
-const $skipLink = document.querySelector('[data-module="govuk-skip-link"]')
-new SkipLink($skipLink)
+createAll(SkipLink)
+// You can provide a config for components that use them
+createAll(CharacterCount, { maxLength: 500 })
 ```
 
-When using a component more than once, the same `import` can be initialised again:
+The `createAll` function will log any errors thrown during components instantiation to the console. If you need to catch these errors, you can instantiate the components manually. You must check your application works without errors or some components will not work correctly.
 
 ```javascript
-import { Radios } from 'govuk-frontend'
+import { SkipLink, CharacterCount } from 'govuk-frontend'
 
-const $radios = document.querySelectorAll('[data-module="govuk-radios"]')
-$radios.forEach(($radio) => {
-  new Radios($radio)
+const $skipLinks = document.querySelectorAll('[data-module="govuk-skip-link"]')
+$skipLinks.forEach(($skipLink) => {
+  new SkipLink($skipLink)
+})
+
+const $characterCounts = document.querySelectorAll('[data-module="govuk-character-count"]')
+$characterCounts.forEach(($characterCount) => {
+  // You can provide a config for components that use them
+  new CharacterCount($characterCount, {maxLength: 500})
 })
 ```
 

--- a/source/javascript-api-reference/index.html.md.erb
+++ b/source/javascript-api-reference/index.html.md.erb
@@ -7,7 +7,7 @@ weight: 80
 
 Some of our components can be passed JavaScript configuration objects. You can do it both:
 
-- [when configuring individual component instances](../configure-components/#with-configuration-object)
+- [when configuring instances of specific components](../configure-components/#configure-instances-of-specific-components-using-the-createall-function)
 - [when configuring all components using the `initAll` function](../configure-components/#configure-all-components-using-the-initall-function)
 
 This page lists the options available for the following components:

--- a/source/localise-govuk-frontend/index.html.md.erb
+++ b/source/localise-govuk-frontend/index.html.md.erb
@@ -130,7 +130,10 @@ With data attributes
 With JavaScript
 
 ```js
-new CharacterCount($element, {
+import { CharacterCount, createAll } from 'govuk-frontend'
+
+// The same config will be used for all CharacterCount on the page
+createAll(CharacterCount, {
   i18n: {
     charactersUnderLimit: {
       other: '%{count} characters to go',


### PR DESCRIPTION
> [!WARNING]
> This PR should only be merged after the next release of GOV.UK Frontend

Updates the Frontend docs to reflect the [addition of a new `createAll` function](https://github.com/alphagov/govuk-frontend/pull/4975) to initialise all instances of a specific component on the page.

Also moves the 'Initialise only part of a page' to the 'Import JavaScript' page, rather than 'Configure components' to regroup both how to import and initialise components.

[Each commit](https://github.com/alphagov/govuk-frontend-docs/pull/443/commits) details the changes of a specific page.

Closes alphagov/govuk-frontend#4945