### PR TITLE
Expand documentation on importing specific bits of the Sass

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -1,5 +1,6 @@
 require "govuk_tech_docs"
 require "lib/header_menu_fix_extension"
+require "lib/package_contents"
 require "lib/sassdocs_helpers"
 require "lib/table_of_contents_helpers"
 
@@ -22,6 +23,7 @@ sprockets.prepend_path File.join(__dir__, "./node_modules/govuk-frontend/")
 config[:tech_docs][:prevent_indexing] = (ENV["GITHUB_REF"] != "refs/heads/main")
 
 helpers do
+  include PackageContents
   include SassdocsHelpers
   include TableOfContentsHelpers
 

--- a/lib/package_contents.rb
+++ b/lib/package_contents.rb
@@ -1,13 +1,22 @@
 module PackageContents
   def components
-    File.readlines("node_modules/govuk-frontend/dist/govuk/components/_index.scss")
-      .map { |line| /@import "(?<component>[a-z-]*)\/index";/.match(line)&.[](:component) }
-      .compact
+    extract_from "components/_index.scss" do |line|
+      # Match anything found between `@import "` and `/index";`
+      line[/(?<=@import ")[a-z-]*(?=\/index";)/]
+    end
   end
 
   def overrides
-    File.readlines("node_modules/govuk-frontend/dist/govuk/overrides/_index.scss")
-      .map { |line| /@import "(?<override>[a-z-]*)";/.match(line)&.[](:override) }
+    extract_from "overrides/_index.scss" do |line|
+      # Match anything found between `@import "` and `";`
+      line[/(?<=@import ")[a-z-]*(?=";)/]
+    end
+  end
+
+  def extract_from(file, &block)
+    File.readlines("node_modules/govuk-frontend/dist/govuk/#{file}")
+      .map(&block)
       .compact
+      .tap { |list| raise "No matches found in #{file}" if list.empty? }
   end
 end

--- a/lib/package_contents.rb
+++ b/lib/package_contents.rb
@@ -1,0 +1,13 @@
+module PackageContents
+  def components
+    File.readlines("node_modules/govuk-frontend/dist/govuk/components/_index.scss")
+      .map { |line| /@import "(?<component>[a-z-]*)\/index";/.match(line)&.[](:component) }
+      .compact
+  end
+
+  def overrides
+    File.readlines("node_modules/govuk-frontend/dist/govuk/overrides/_index.scss")
+      .map { |line| /@import "(?<override>[a-z-]*)";/.match(line)&.[](:override) }
+      .compact
+  end
+end

--- a/source/import-css/index.html.md.erb
+++ b/source/import-css/index.html.md.erb
@@ -42,18 +42,92 @@ If you want to improve how quickly your service's pages load in browsers, you ca
 1. Import `node_modules/govuk-frontend/dist/govuk/base` in your Sass file.
 2. Import the parts of the CSS you need.
 
-For example, add the following to your Sass file to import the CSS you need for a basic GOV.UK page.
+The biggest optimisations you can make are to include just the components and overrides that you are using.
 
 ```scss
+// 'Base' includes everything from settings, tools and helpers. Nothing
+// in the base outputs any actual CSS.
+
 @import "node_modules/govuk-frontend/dist/govuk/base";
 
+// Basic content styles for typography, links etc. Approximately 10% of
+// the CSS output if you include everything.
+
 @import "node_modules/govuk-frontend/dist/govuk/core/index";
+
+// Objects include things like the page template, grid, form groups.
+// Approximately 5% of the CSS output if you include everything.
+
 @import "node_modules/govuk-frontend/dist/govuk/objects/index";
+
+// The components themselves - try to only include the components you
+// are using in your project. Approximately 70% of the CSS output if
+// you include everything.
+
+@import "node_modules/govuk-frontend/dist/govuk/components/accordion/index";
+@import "node_modules/govuk-frontend/dist/govuk/components/back-link/index";
+@import "node_modules/govuk-frontend/dist/govuk/components/breadcrumbs/index";
+@import "node_modules/govuk-frontend/dist/govuk/components/button/index";
+@import "node_modules/govuk-frontend/dist/govuk/components/character-count/index";
+@import "node_modules/govuk-frontend/dist/govuk/components/checkboxes/index";
+@import "node_modules/govuk-frontend/dist/govuk/components/cookie-banner/index";
+@import "node_modules/govuk-frontend/dist/govuk/components/date-input/index";
+@import "node_modules/govuk-frontend/dist/govuk/components/details/index";
+@import "node_modules/govuk-frontend/dist/govuk/components/error-message/index";
+@import "node_modules/govuk-frontend/dist/govuk/components/error-summary/index";
+@import "node_modules/govuk-frontend/dist/govuk/components/exit-this-page/index";
+@import "node_modules/govuk-frontend/dist/govuk/components/fieldset/index";
+@import "node_modules/govuk-frontend/dist/govuk/components/file-upload/index";
 @import "node_modules/govuk-frontend/dist/govuk/components/footer/index";
 @import "node_modules/govuk-frontend/dist/govuk/components/header/index";
+@import "node_modules/govuk-frontend/dist/govuk/components/hint/index";
+@import "node_modules/govuk-frontend/dist/govuk/components/input/index";
+@import "node_modules/govuk-frontend/dist/govuk/components/inset-text/index";
+@import "node_modules/govuk-frontend/dist/govuk/components/label/index";
+@import "node_modules/govuk-frontend/dist/govuk/components/notification-banner/index";
+@import "node_modules/govuk-frontend/dist/govuk/components/pagination/index";
+@import "node_modules/govuk-frontend/dist/govuk/components/panel/index";
+@import "node_modules/govuk-frontend/dist/govuk/components/password-input/index";
+@import "node_modules/govuk-frontend/dist/govuk/components/phase-banner/index";
+@import "node_modules/govuk-frontend/dist/govuk/components/radios/index";
+@import "node_modules/govuk-frontend/dist/govuk/components/select/index";
 @import "node_modules/govuk-frontend/dist/govuk/components/skip-link/index";
+@import "node_modules/govuk-frontend/dist/govuk/components/summary-list/index";
+@import "node_modules/govuk-frontend/dist/govuk/components/table/index";
+@import "node_modules/govuk-frontend/dist/govuk/components/tabs/index";
+@import "node_modules/govuk-frontend/dist/govuk/components/tag/index";
+@import "node_modules/govuk-frontend/dist/govuk/components/task-list/index";
+@import "node_modules/govuk-frontend/dist/govuk/components/textarea/index";
+@import "node_modules/govuk-frontend/dist/govuk/components/warning-text/index";
+
+// Utilities, for example govuk-clearfix or govuk-visually-hidden.
+// Approximately 1% of the CSS output if you include everything.
+
 @import "node_modules/govuk-frontend/dist/govuk/utilities/index";
+
+// Overrides, used to tweak things like the amount of spacing on an
+// element. Override classes always include `-!-` in the class name.
+// Approximately 15% of the CSS output if you include everything.
+
 @import "node_modules/govuk-frontend/dist/govuk/overrides/index";
+
+// Alternatively, you can import the specific groups of overrides
+// you need for your project:
+//
+// Display, for example govuk-!-display-inline
+// @import "node_modules/govuk-frontend/dist/govuk/overrides/display";
+//
+// Spacing, for example govuk-!-margin-4, govuk-!-static-padding-4
+// @import "node_modules/govuk-frontend/dist/govuk/overrides/spacing";
+//
+// Text alignment, for example govuk-!-text-align-left
+// @import "node_modules/govuk-frontend/dist/govuk/overrides/text-align";
+//
+// Typography, for example govuk-!-font-size-19, govuk-!-font-weight-bold
+// @import "node_modules/govuk-frontend/dist/govuk/overrides/typography";
+//
+// Width, for example govuk-!-width-two-thirds
+// @import "node_modules/govuk-frontend/dist/govuk/overrides/width";
 ```
 
 You can remove lines that import parts of the CSS you do not need.

--- a/source/import-css/index.html.md.erb
+++ b/source/import-css/index.html.md.erb
@@ -40,13 +40,15 @@ To import all the Sass rules from GOV.UK Frontend, add the following to your Sas
 If you want to improve how quickly your service's pages load in browsers, you can import only the Sass rules you need.
 
 1. Import `node_modules/govuk-frontend/dist/govuk/base` in your Sass file.
-2. Import the parts of the CSS you need.
+2. Import only the Sass you need based on the components and other classes your service is using.
 
-The biggest optimisations you can make are to include just the components and overrides that you are using.
+The biggest optimisations come from excluding any components or overrides you're not using.
+
+You must import the layers in the order listed in the example below.
 
 ```scss
 // 'Base' includes everything from settings, tools and helpers. Nothing
-// in the base outputs any actual CSS.
+// in the base outputs any CSS.
 
 @import "node_modules/govuk-frontend/dist/govuk/base";
 
@@ -55,7 +57,7 @@ The biggest optimisations you can make are to include just the components and ov
 
 @import "node_modules/govuk-frontend/dist/govuk/core/index";
 
-// Objects include things like the page template, grid, form groups.
+// Objects include things like the page template, grid and form groups.
 // Approximately 5% of the CSS output if you include everything.
 
 @import "node_modules/govuk-frontend/dist/govuk/objects/index";
@@ -68,17 +70,23 @@ The biggest optimisations you can make are to include just the components and ov
 @import "node_modules/govuk-frontend/dist/govuk/components/<%= component %>/index";
 <% end %>
 
+/*
+// Alternatively, you can import all components:
+@import "node_modules/govuk-frontend/dist/govuk/components/index";
+*/
+
 // Utilities, for example govuk-clearfix or govuk-visually-hidden.
 // Approximately 1% of the CSS output if you include everything.
 
 @import "node_modules/govuk-frontend/dist/govuk/utilities/index";
 
-// Overrides, used to tweak things like the amount of spacing on an
+// Overrides, used to adjust things like the amount of spacing on an
 // element. Override classes always include `-!-` in the class name.
 // Approximately 15% of the CSS output if you include everything.
 
 @import "node_modules/govuk-frontend/dist/govuk/overrides/index";
 
+/*
 // Alternatively, you can import the specific groups of overrides
 // you need for your project:
 <% examples = {
@@ -89,10 +97,11 @@ The biggest optimisations you can make are to include just the components and ov
   'width' => %w(govuk-!-width-two-thirds)
 } %>
 <% overrides.each do |override| %>
-//
-// <%= override.titleize %><% if examples.key?(override) %>, for example <%= examples[override].join(', ') %><% end %>
-// @import "node_modules/govuk-frontend/dist/govuk/overrides/<%= override %>";
+
+// <%= override.sub('-', ' ').humanize %> overrides<% if examples.key?(override) %> - for example <%= examples[override].join(', ') %><% end %>
+@import "node_modules/govuk-frontend/dist/govuk/overrides/<%= override %>";
 <% end %>
+*/
 ```
 
 You can remove lines that import parts of the CSS you do not need.

--- a/source/import-css/index.html.md.erb
+++ b/source/import-css/index.html.md.erb
@@ -64,41 +64,9 @@ The biggest optimisations you can make are to include just the components and ov
 // are using in your project. Approximately 70% of the CSS output if
 // you include everything.
 
-@import "node_modules/govuk-frontend/dist/govuk/components/accordion/index";
-@import "node_modules/govuk-frontend/dist/govuk/components/back-link/index";
-@import "node_modules/govuk-frontend/dist/govuk/components/breadcrumbs/index";
-@import "node_modules/govuk-frontend/dist/govuk/components/button/index";
-@import "node_modules/govuk-frontend/dist/govuk/components/character-count/index";
-@import "node_modules/govuk-frontend/dist/govuk/components/checkboxes/index";
-@import "node_modules/govuk-frontend/dist/govuk/components/cookie-banner/index";
-@import "node_modules/govuk-frontend/dist/govuk/components/date-input/index";
-@import "node_modules/govuk-frontend/dist/govuk/components/details/index";
-@import "node_modules/govuk-frontend/dist/govuk/components/error-message/index";
-@import "node_modules/govuk-frontend/dist/govuk/components/error-summary/index";
-@import "node_modules/govuk-frontend/dist/govuk/components/exit-this-page/index";
-@import "node_modules/govuk-frontend/dist/govuk/components/fieldset/index";
-@import "node_modules/govuk-frontend/dist/govuk/components/file-upload/index";
-@import "node_modules/govuk-frontend/dist/govuk/components/footer/index";
-@import "node_modules/govuk-frontend/dist/govuk/components/header/index";
-@import "node_modules/govuk-frontend/dist/govuk/components/hint/index";
-@import "node_modules/govuk-frontend/dist/govuk/components/input/index";
-@import "node_modules/govuk-frontend/dist/govuk/components/inset-text/index";
-@import "node_modules/govuk-frontend/dist/govuk/components/label/index";
-@import "node_modules/govuk-frontend/dist/govuk/components/notification-banner/index";
-@import "node_modules/govuk-frontend/dist/govuk/components/pagination/index";
-@import "node_modules/govuk-frontend/dist/govuk/components/panel/index";
-@import "node_modules/govuk-frontend/dist/govuk/components/password-input/index";
-@import "node_modules/govuk-frontend/dist/govuk/components/phase-banner/index";
-@import "node_modules/govuk-frontend/dist/govuk/components/radios/index";
-@import "node_modules/govuk-frontend/dist/govuk/components/select/index";
-@import "node_modules/govuk-frontend/dist/govuk/components/skip-link/index";
-@import "node_modules/govuk-frontend/dist/govuk/components/summary-list/index";
-@import "node_modules/govuk-frontend/dist/govuk/components/table/index";
-@import "node_modules/govuk-frontend/dist/govuk/components/tabs/index";
-@import "node_modules/govuk-frontend/dist/govuk/components/tag/index";
-@import "node_modules/govuk-frontend/dist/govuk/components/task-list/index";
-@import "node_modules/govuk-frontend/dist/govuk/components/textarea/index";
-@import "node_modules/govuk-frontend/dist/govuk/components/warning-text/index";
+<% components.each do |component| %>
+@import "node_modules/govuk-frontend/dist/govuk/components/<%= component %>/index";
+<% end %>
 
 // Utilities, for example govuk-clearfix or govuk-visually-hidden.
 // Approximately 1% of the CSS output if you include everything.
@@ -113,21 +81,18 @@ The biggest optimisations you can make are to include just the components and ov
 
 // Alternatively, you can import the specific groups of overrides
 // you need for your project:
+<% examples = {
+  'display' => %w(govuk-!-display-inline),
+  'spacing' => %w(govuk-!-margin-4 govuk-!-static-padding-4),
+  'text-align' => %w(govuk-!-text-align-left),
+  'typography' => %w(govuk-!-font-size-19 govuk-!-font-weight-bold),
+  'width' => %w(govuk-!-width-two-thirds)
+} %>
+<% overrides.each do |override| %>
 //
-// Display, for example govuk-!-display-inline
-// @import "node_modules/govuk-frontend/dist/govuk/overrides/display";
-//
-// Spacing, for example govuk-!-margin-4, govuk-!-static-padding-4
-// @import "node_modules/govuk-frontend/dist/govuk/overrides/spacing";
-//
-// Text alignment, for example govuk-!-text-align-left
-// @import "node_modules/govuk-frontend/dist/govuk/overrides/text-align";
-//
-// Typography, for example govuk-!-font-size-19, govuk-!-font-weight-bold
-// @import "node_modules/govuk-frontend/dist/govuk/overrides/typography";
-//
-// Width, for example govuk-!-width-two-thirds
-// @import "node_modules/govuk-frontend/dist/govuk/overrides/width";
+// <%= override.titleize %><% if examples.key?(override) %>, for example <%= examples[override].join(', ') %><% end %>
+// @import "node_modules/govuk-frontend/dist/govuk/overrides/<%= override %>";
+<% end %>
 ```
 
 You can remove lines that import parts of the CSS you do not need.

--- a/spec/package_contents_spec.rb
+++ b/spec/package_contents_spec.rb
@@ -1,0 +1,63 @@
+require_relative "../lib/package_contents"
+
+class Test
+  include PackageContents
+end
+
+RSpec.describe PackageContents do
+  before(:all) do
+    @helper = Test.new
+  end
+
+  describe "#components" do
+    it "extracts components from components/_index.scss" do
+      allow(File).to receive(:readlines).and_return <<~FILE.split("\n")
+        @import "../base";
+
+        @import "first-component/index";
+        @import "second-component/index";
+        @import "third-component/index";
+      FILE
+
+      expect(@helper.components).to eq(%w[
+        first-component
+        second-component
+        third-component
+      ])
+    end
+
+    it "throws if no components are found in components/_index.scss" do
+      allow(File).to receive(:readlines).and_return []
+
+      expect { @helper.components }.to raise_error(
+        "No matches found in components/_index.scss",
+      )
+    end
+  end
+
+  describe "#overrides" do
+    it "extracts overrides from overrides/_index.scss" do
+      allow(File).to receive(:readlines).and_return <<~FILE.split("\n")
+        @import "../a-dependency";
+
+        @import "one";
+        @import "two";
+        @import "th-ree";
+      FILE
+
+      expect(@helper.overrides).to eq(%w[
+        one
+        two
+        th-ree
+      ])
+    end
+
+    it "throws if no overrides are found in components/_index.scss" do
+      allow(File).to receive(:readlines).and_return []
+
+      expect { @helper.overrides }.to raise_error(
+        "No matches found in overrides/_index.scss",
+      )
+    end
+  end
+end


### PR DESCRIPTION
Provide a more exhaustive example of how to import specific bits of our Sass, allowing users to understand what's possible without having to go digging through the code.

Specifically, document the full list of components and overrides as they comprise the greatest percentage of the generated CSS (70% and 15% respectively) and are least likely to be fully used.

I've also opted to include some approximate percentages to give users an indication of the weight of each layer. These percentages will be less accurate over time as the composition of our Sass changes, but I think they're likely to remain accurate enough to be useful.

👉🏻 [Have a look](https://deploy-preview-445--govuk-frontend-docs-preview.netlify.app/import-css/#import-specific-parts-using-sass) 👀 