### PR TITLE
Update existing pages ahead of 5.7.0 release

### DIFF
--- a/source/import-css/index.html.md.erb
+++ b/source/import-css/index.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Import CSS, assets and JavaScript
+title: Import CSS
 weight: 30
 ---
 

--- a/source/import-javascript/index.html.md.erb
+++ b/source/import-javascript/index.html.md.erb
@@ -77,22 +77,50 @@ createAll(SkipLink)
 createAll(CharacterCount, { maxLength: 500 })
 ```
 
-The `createAll` function will log any errors thrown during components instantiation to the console. If you need to catch these errors, you can instantiate the components manually. You must check your application works without errors or some components will not work correctly.
+#### Handling errors during instantiation
+
+The `createAll` function will log any errors thrown during components instantiation to the console. If you need to catch these errors, you can use [its `onError` option](../building-your-own-javascript-components/#handling-initialisation-errors).
+
+
+```javascript
+import { SkipLink, CharacterCount, createAll } from 'govuk-frontend'
+
+createAll(SkipLink, function(error) {
+  // Handle the error here, for example send it to an error monitoring service
+})
+// You can provide a config for components that use them
+createAll(CharacterCount, { maxLength: 500 }, function(error) {
+  // Handle the error here, for example send it to an error monitoring service
+})
+```
+
+You can also instantiate components manually.
 
 ```javascript
 import { SkipLink, CharacterCount } from 'govuk-frontend'
 
 const $skipLinks = document.querySelectorAll('[data-module="govuk-skip-link"]')
 $skipLinks.forEach(($skipLink) => {
-  new SkipLink($skipLink)
+  try {
+    new SkipLink($skipLink)
+  } catch (error) {
+    // Handle the error here, for example send it to an error monitoring service
+  }
 })
 
 const $characterCounts = document.querySelectorAll('[data-module="govuk-character-count"]')
 $characterCounts.forEach(($characterCount) => {
-  // You can provide a config for components that use them
-  new CharacterCount($characterCount, {maxLength: 500})
+  
+  try {
+    // You can provide a config for components that use them
+    new CharacterCount($characterCount, {maxLength: 500})
+  } catch (error) {
+    // Handle the error here, for example send it to an error monitoring service
+  }
 })
 ```
+
+You must check your application works without errors or some components will not work correctly.
 
 ### Import and initialise all components using the initAll function
 

--- a/source/import-javascript/index.html.md.erb
+++ b/source/import-javascript/index.html.md.erb
@@ -26,6 +26,8 @@ Next, to import the JavaScript from GOV.UK Frontend, you can either:
 - add the JavaScript file to your HTML
 - import the JavaScript into your own JavaScript file using a bundler
 
+Once imported, you can check if GOV.UK Frontend is supported using [the `isSupported` function](../building-your-own-javascript-components/#checking-for-gov-uk-frontend-support-with-issupported).
+
 ## Add the JavaScript file to your HTML
 
 If you decide to add the JavaScript to your HTML, you can do one of the following:

--- a/source/import-javascript/index.html.md.erb
+++ b/source/import-javascript/index.html.md.erb
@@ -120,7 +120,7 @@ $characterCounts.forEach(($characterCount) => {
 })
 ```
 
-You must check your application works without errors or some components will not work correctly.
+You must check that your application works without errors, or some components will not work correctly.
 
 ### Import and initialise all components using the initAll function
 

--- a/source/installing-with-npm/index.html.md.erb
+++ b/source/installing-with-npm/index.html.md.erb
@@ -108,9 +108,9 @@ In your live application, we recommend [using an automated task or your build pi
 
 4. Run your application and check it works the same way as the Design System accordion example, by selecting the buttons and checking the accordion shows and hides sections.
 
-In your live application:
+In your live application, we recommend:
 
-- use `initAll` to initialise all components that use GOV.UK Frontend's JavaScript, or some components will not work correctly for disabled users who use assistive technologies
-- we recommend [using an automated task or your build pipeline](../import-javascript/) instead of copying the files manually
+- [using an automated task or your build pipeline](../import-javascript/) instead of copying the files manually
+- importing only the components your application uses and [using `createAll` to initialise](../import-javascript/#import-individual-components) all their instances on the page. Make sure you import all the components used throughout your application or some components will not work correctly for disabled users who use assistive technologies.
 
 Once your testing is complete you can use the full code for page layouts and other components from the [Design System website](https://design-system.service.gov.uk/).

--- a/source/installing-with-npm/index.html.md.erb
+++ b/source/installing-with-npm/index.html.md.erb
@@ -111,6 +111,8 @@ In your live application, we recommend [using an automated task or your build pi
 In your live application, we recommend:
 
 - [using an automated task or your build pipeline](../import-javascript/) instead of copying the files manually
-- importing only the components your application uses and [using `createAll` to initialise](../import-javascript/#import-individual-components) all their instances on the page. Make sure you import all the components used throughout your application or some components will not work correctly for disabled users who use assistive technologies.
+- importing only the components your application uses and [using `createAll` to initialise](../import-javascript/#import-individual-components) all their instances on the page
+
+Make sure you import all the components used throughout your application or some components will not work correctly for disabled users who use assistive technologies.
 
 Once your testing is complete you can use the full code for page layouts and other components from the [Design System website](https://design-system.service.gov.uk/).


### PR DESCRIPTION
* Add some links to the new 'Building your own components' page (see #468)
* Fixes the title of the 'Import CSS' page
* Updates the 'Get the JavaScript working' to encourage importing individual components (missed in 5.4.0).

This PR is best reviewed commit by commit, each affecting the following sections:

1. ['Before you start' in 'Import JavaScript'](https://deploy-preview-469--govuk-frontend-docs-preview.netlify.app/import-javascript/#before-you-start)
2. ['Import individual components' in 'Import JavaScript'](https://deploy-preview-469--govuk-frontend-docs-preview.netlify.app/import-javascript/#import-individual-components)
3. ['Get the JavaScript working' in 'Install with Node.js package manager (npm)'](https://deploy-preview-469--govuk-frontend-docs-preview.netlify.app/installing-with-npm/#get-the-javascript-working)
4. The title of the ['Import CSS'](https://deploy-preview-469--govuk-frontend-docs-preview.netlify.app/import-css/) page
