### PR TITLE
Fix runner Ubuntu to 22

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     name: Build & Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
We're having some problems with Ubuntu 24, so fixing to 22 while we sort them.