### PR TITLE
Fix misformatted codeblock in install-with-npm page

### DIFF
--- a/source/installing-with-npm/index.html.md.erb
+++ b/source/installing-with-npm/index.html.md.erb
@@ -65,9 +65,9 @@ The accordion will use a generic font until you get the font and images working,
 
 There are also different ways you can [import GOV.UK Frontend's CSS](../import-css/), including into your project's main Sass file:
 
-    ```scss
-    @import "node_modules/govuk-frontend/dist/govuk/index";
-    ```
+```scss
+@import "node_modules/govuk-frontend/dist/govuk/index";
+```
 
 You do not need `/index` at the end of your import if you’re using Dart Sass, LibSass 3.6.0 or higher, or Ruby Sass 3.6.0 or higher.
 


### PR DESCRIPTION
The intentation was making Markdown consider the fenced block part of the content rather than the start of the code block and rendering the following on the page:

~~~
```scss
@import "node_modules/govuk-frontend/dist/govuk/index";
```
~~~

It now correctly renders:

```scss
@import "node_modules/govuk-frontend/dist/govuk/index";
```

Before: https://frontend.design-system.service.gov.uk/installing-with-npm/#get-the-css-assets-and-javascript-working
After: https://deploy-preview-506--govuk-frontend-docs-preview.netlify.app/installing-with-npm/#get-the-css-working

Fixes #505 