### PR TITLE
Remove pre-release installation instructions

### DIFF
--- a/source/staying-up-to-date/index.html.md.erb
+++ b/source/staying-up-to-date/index.html.md.erb
@@ -135,12 +135,6 @@ If you want to install the most recent version of GOV.UK Frontend v4.x, run:
 npm install govuk-frontend@latest-v4
 ```
 
-If you want to install the most recent pre-release, run:
-
-```console
-npm install govuk-frontend@next
-```
-
 ### Updating to the latest version if you installed GOV.UK Frontend using precompiled files
 
 Follow the instructions on the page ['Try GOV.UK Frontend using precompiled files'](/install-using-precompiled-files/), replacing any files that already exist.


### PR DESCRIPTION
We don't do pre-releases very often, so the version behind the "next" tag is usually pretty out of date.

We can encourage folks to try the "next" tag via comms when we need wider testing. Most of the active port maintainers are already pretty on top of this anyway.