### PR TITLE
Remove deprecated `reviewers` option from Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,6 @@
 version: 2
 
 updates:
-
   # Update npm packages
   - package-ecosystem: npm
     directory: /
@@ -12,10 +11,8 @@ updates:
       # First in list so Dependabot looks at updating those first
       design-system:
         patterns:
-          - 'govuk-frontend'
-          - 'accessible-autocomplete'
-    reviewers:
-      - alphagov/design-system-developers
+          - "govuk-frontend"
+          - "accessible-autocomplete"
     schedule:
       # Defaults to weekly on Monday
       interval: monthly
@@ -30,8 +27,6 @@ updates:
   # Update Ruby gems
   - package-ecosystem: bundler
     directory: /
-    reviewers:
-      - alphagov/design-system-developers
     schedule:
       # Defaults to weekly on Monday
       interval: monthly
@@ -46,8 +41,6 @@ updates:
   # Update GitHub Actions
   - package-ecosystem: github-actions
     directory: /
-    reviewers:
-      - alphagov/design-system-developers
     schedule:
       # Defaults to weekly on Monday
       interval: monthly

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,12 @@
 # CI/CD (which has access to secrets and to production)
 .github/workflows/  @alphagov/design-system-developers
+
+# Track changes to package.json or package-lock.json
+/package*.json  @alphagov/design-system-developers
+
+# Track changes to Gemfiles
+/Gemfile  @alphagov/design-system-developers
+/Gemfile.lock  @alphagov/design-system-developers
+
+# Protect the CODEOWNERS file itself against malicious changes
+CODEOWNERS  @alphagov/design-system-developers


### PR DESCRIPTION
Dependabot's `reviewers` option is being removed on 27th May, with its functionality being merged with the `CODEOWNERS` file, [as described on the GitHub blog](https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/).

## Changes
- Updates the `CODEOWNERS` file to include the **root** `package.json` and `package-lock.json` files explicitly, to match npm dependencies being protected by the `reviewers` option in Dependabot's config.
- Updates the `CODEOWNERS` file to include `Gemfile` and `Gemfile.lock`, to match the prior protection for gem updates.
- Updates the `CODEOWNERS` file to include the `CODEOWNERS` file itself, requiring approval from codeowners to change it in future. [This is a recommended security practice.](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-and-branch-protection)
- Removes the `reviewers` option from Dependabot config.
