### PR TITLE
Draft changes to tech docs for v4 brand update

### DIFF
--- a/source/changes-to-govuk-frontend-v5/index.html.md.erb
+++ b/source/changes-to-govuk-frontend-v5/index.html.md.erb
@@ -25,7 +25,7 @@ If you need it, we have a checklist for the changes you might need to make for v
 
 If you still need to provide support for older versions of Internet Explorer, you should stay on the latest [GOV.UK Frontend v4 release](https://github.com/alphagov/govuk-frontend/tags).
 
-We're supporting GOV.UK Frontend v4 until 08 December 2024. We will conduct a review before this date to decide if we need to extend our support.
+We do not plan to make any further updates to GOV.UK Frontend v4.
 
 ## Benefits of updating to v5
 
@@ -91,3 +91,15 @@ The main accessibility changes are:
 - the accessible name for the [header menu](https://design-system.service.gov.uk/components/header/#header-with-service-name-and-navigation) has been changed from "show or hide menu" to "menu", to remove duplicate announcements ([govuk-frontend #3696](https://github.com/alphagov/govuk-frontend/issues/3696))
 - [smaller checkboxes](https://design-system.service.gov.uk/components/checkboxes/#smaller-checkboxes) and [smaller radios](https://design-system.service.gov.uk/components/radios/#smaller-radios) now have a hover state for contrast modes like Windows High Contrast Mode ([govuk-frontend #3695](https://github.com/alphagov/govuk-frontend/issues/3695))
 - [pagination links](https://design-system.service.gov.uk/components/pagination/) for "Next" and "Previous" now have expanded accessible names of "Next page" and "Previous page" ([govuk-frontend #3679](https://github.com/alphagov/govuk-frontend/issues/3679))
+
+## Brand refresh changes to v4 and v5
+
+We’ve added features from the latest version of GOV.UK Frontend to help more services implement GOV.UK’s refreshed brand. Ahead of the brand’s go-live date of 25 June 2025, you should prepare your service by updating its code. You’ll then need to deploy the changes to production on 25 June 2025 or as soon after this date as possible.
+
+These changes affect these components:
+
+- [GOV.UK header](https://design-system.service.gov.uk/components/header/)
+- [GOV.UK footer](https://design-system.service.gov.uk/components/footer/)
+- [Cookie banner](https://design-system.service.gov.uk/components/cookie-banner/)
+
+We're supporting a refresh of the brand for both v4 and v5. See the [v4.10.0 release notes](https://github.com/alphagov/govuk-frontend/releases/tag/v4.10.0) and [v5.10.0 release notes](https://github.com/alphagov/govuk-frontend/releases/tag/v5.10.0) to see more details and how to update.


### PR DESCRIPTION
## What 
Update to Changes to GOV.UK Frontend v5.0.0 to reflect the work we're doing to support adopting the GOV.UK rebrand.

## Why
Users of v4 and v5 are able to understand the context of us supporting an update to the rebrand. We also include that we are not planning to support any future updates to v4.