### PR TITLE
Update govuk-frontend versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.0.0",
       "hasInstallScript": true,
       "devDependencies": {
-        "govuk-frontend": "^5.10.1",
-        "govuk-frontend-v4": "npm:govuk-frontend@^4.9.0",
+        "govuk-frontend": "^5.10.2",
+        "govuk-frontend-v4": "npm:govuk-frontend@^4.10.0",
         "hyperlink": "^5.0.4",
         "sassdoc": "^2.7.4",
         "standard": "^17.1.2",
@@ -4536,9 +4536,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.10.1.tgz",
-      "integrity": "sha512-VmzKE+pkuOqEXhit0cGqic4i2mOQwflfXDiEcsa6Lrqs//rxV5AYf+C71jbREPwQLH4wYSJAlz/GlGoO5nik7Q==",
+      "version": "5.10.2",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.10.2.tgz",
+      "integrity": "sha512-eVYB2rfUCihehZFHQyylt12/OuXq2JLs+70igcrB1FmbepcDqs1XwKiq96hsPbPF9Vn2f6QXO1OatyD3bq5c9Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4547,9 +4547,9 @@
     },
     "node_modules/govuk-frontend-v4": {
       "name": "govuk-frontend",
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.9.0.tgz",
-      "integrity": "sha512-zfX+GBUKpWBeV6JwCIawEuI8VRWlskH8Ok8aNUjKOvzo3zIaNbcrv4IOwgy+oSnMoGh67Eeh+vb7+9GFxN2fNg==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.10.0.tgz",
+      "integrity": "sha512-oHwHdpycGZ7H6Skual1teBWN+0b+PYirifJkX8tQz1m7UWZb4JapppuOaVzcLD+11Q1hqqUJgR3gXDCosO9d4w==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "check-links": "hyperlink --canonicalroot https://frontend.design-system.service.gov.uk --internal --recursive build/index.html --skip 'property=\"og:image\"' | tee check-links.log | tap-mocha-reporter min"
   },
   "devDependencies": {
-    "govuk-frontend": "^5.10.1",
-    "govuk-frontend-v4": "npm:govuk-frontend@^4.9.0",
+    "govuk-frontend": "^5.10.2",
+    "govuk-frontend-v4": "npm:govuk-frontend@^4.10.0",
     "hyperlink": "^5.0.4",
     "sassdoc": "^2.7.4",
     "standard": "^17.1.2",


### PR DESCRIPTION
Updates the main site from 5.10.1 to 5.10.2 and the v4 site from 4.9.0 to 4.10.0