### PR TITLE
Update outdated link to plural rules chart

### DIFF
--- a/source/localise-govuk-frontend/index.html.md.erb
+++ b/source/localise-govuk-frontend/index.html.md.erb
@@ -84,7 +84,7 @@ The forms for each language will differ depending on its pluralisation. For exam
 - some languages will require you to pass additional forms
 - languages with no plural form only need the form `other`
 
-You should use a professional translation service to make sure your translation is accurate and that you're using the correct pluralisation form. You can also check [the Unicode Common Locale Data Repository documentation for guidance on which of these forms your locale requires and what `few` and `many` might represent for it](https://unicode-org.github.io/cldr-staging/charts/latest/supplemental/language_plural_rules.html).
+You should use a professional translation service to make sure your translation is accurate and that you're using the correct pluralisation form. You can also check [the Unicode Common Locale Data Repository documentation for guidance on which of these forms your locale requires and what `few` and `many` might represent for it](https://www.unicode.org/cldr/charts/latest/supplemental/language_plural_rules.html).
 
 When providing text with plural forms, you'll need to pass an object associating each plural category with the text for that form. If you do not provide the required plural form for the locale, the component will fall back to the "other" form and warn you in the browser console.
 

--- a/source/v4/localise-govuk-frontend/index.html.md.erb
+++ b/source/v4/localise-govuk-frontend/index.html.md.erb
@@ -84,7 +84,7 @@ The forms for each language will differ depending on its pluralisation. For exam
 - some languages will require you to pass additional forms
 - languages with no plural form only need the form `other`
 
-You should use a professional translation service to make sure your translation is accurate and that you're using the correct pluralisation form. You can also check [the Unicode Common Locale Data Repository documentation for guidance on which of these forms your locale requires and what `few` and `many` might represent for it](https://unicode-org.github.io/cldr-staging/charts/latest/supplemental/language_plural_rules.html).
+You should use a professional translation service to make sure your translation is accurate and that you're using the correct pluralisation form. You can also check [the Unicode Common Locale Data Repository documentation for guidance on which of these forms your locale requires and what `few` and `many` might represent for it](https://www.unicode.org/cldr/charts/latest/supplemental/language_plural_rules.html).
 
 When providing text with plural forms, you'll need to pass an object associating each plural category with the text for that form. If you do not provide the required plural form for the locale, the component will fall back to the "other" form and warn you in the browser's console.
 


### PR DESCRIPTION
The link https://unicode-org.github.io/cldr-staging/charts/latest/supplemental/language_plural_rules.html is outdated – it redirects to the homepage for the staging site with a banner that says 'We've Moved! Please update your links.'

I believe I've found [the equivalent page on the new domain](https://www.unicode.org/cldr/charts/47/supplemental/language_plural_rules.html). Preserving the `latest` in the URL redirects to the chart as it exists in the latest CLDR version.