### PR TITLE
Fix case of `component` in onError context object

### DIFF
--- a/source/building-your-own-javascript-components/index.html.md.erb
+++ b/source/building-your-own-javascript-components/index.html.md.erb
@@ -210,7 +210,7 @@ You can use a function as a third argument to respond to errors being thrown whi
 
 The context object will contain the following properties:
 
-- `Component`: The component class being initialised
+- `component`: The component class being initialised
 - `element`: The element the component is being initialised on
 - `config`: The configuration used for initialisation
 


### PR DESCRIPTION
The `context` object passed to the `onError` callback [includes a lowercase `component` property][1], not `Component` as the docs currently suggest.

[1]: https://github.com/alphagov/govuk-frontend/blob/14366fd816136ec0a425e0a807ae114b2781edbc/packages/govuk-frontend/src/govuk/init.mjs#L214