### PR TITLE
Disable sassdoc’s update notifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "version": "1.0.0",
   "scripts": {
     "postinstall": "npm run build:sassdoc && npm run build:sassdocv4",
-    "build:sassdoc": "sassdoc --parse node_modules/govuk-frontend/dist/govuk/ > data/sassdoc.json",
-    "build:sassdocv4": "sassdoc --parse node_modules/govuk-frontend-v4/govuk/ > data/sassdoc-v4.json",
+    "build:sassdoc": "sassdoc --no-update-notifier --parse node_modules/govuk-frontend/dist/govuk/ > data/sassdoc.json",
+    "build:sassdocv4": "sassdoc --no-update-notifier --parse node_modules/govuk-frontend-v4/govuk/ > data/sassdoc-v4.json",
     "lint": "standard",
     "check-links": "hyperlink --canonicalroot https://frontend.design-system.service.gov.uk --internal --recursive build/index.html --skip 'property=\"og:image\"' | tee check-links.log | tap-mocha-reporter min"
   },


### PR DESCRIPTION
Sassdoc has a built in ‘update notifier’ which is triggering a [security alert via its dependency on `got`][1].

This is highly unlikely to affect us but we may as well disable this feature anyway given that:

1. we have Dependabot handling updates for us
2. it saves a network request, which may speed things up locally and makes it less likely a failing network request affects a CI run

[1]: https://github.com/advisories/GHSA-pfrx-2q88-qq97