### PR TITLE
Remove incorrect Dependabot schedule comment

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,10 +14,8 @@ updates:
           - "govuk-frontend"
           - "accessible-autocomplete"
     schedule:
-      # Defaults to weekly on Monday
       interval: monthly
       time: "10:30"
-      # Setting a timezone so we let dependabot worry about BST
       timezone: "Europe/London"
     versioning-strategy: increase
 
@@ -28,10 +26,8 @@ updates:
   - package-ecosystem: bundler
     directory: /
     schedule:
-      # Defaults to weekly on Monday
       interval: monthly
       time: "10:30"
-      # Setting a timezone so we let dependabot worry about BST
       timezone: "Europe/London"
     versioning-strategy: increase
 
@@ -42,8 +38,6 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      # Defaults to weekly on Monday
       interval: monthly
       time: "10:30"
-      # Setting a timezone so we let dependabot worry about BST
       timezone: "Europe/London"


### PR DESCRIPTION
We’ve moved to monthly Dependabot checks, but didn’t update the comment.

Given the config is pretty self-explanatory, remove the BARE-FACED LIES rather than update them.