### PR TITLE
Update GOV.UK Frontend to 5.11.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "hasInstallScript": true,
       "devDependencies": {
-        "govuk-frontend": "^5.11.1",
+        "govuk-frontend": "^5.11.2",
         "govuk-frontend-v4": "npm:govuk-frontend@^4.10.1",
         "hyperlink": "^5.0.4",
         "sassdoc": "^2.7.4",
@@ -18,7 +18,7 @@
       },
       "engines": {
         "node": "^22.11.0",
-        "npm": "^10.1.0"
+        "npm": "^10.5.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -4536,9 +4536,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.11.1",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.11.1.tgz",
-      "integrity": "sha512-hJJFpaer4MZLvz/2F9RZ7xZ6FqlzpxL9aw6YWOGK3F1tn419xj2WcVXwOC8Bcj/dc/LanknbWJDGkb+IdkuhTQ==",
+      "version": "5.11.2",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.11.2.tgz",
+      "integrity": "sha512-eHV8EMxYNjc+omFhB0HktQ3QmA3ZRdDsgRDlUIik+TpUHerR3XKXpo4zh/OGO2/C2mz65cX0XT0k4QrRFJZU8Q==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "check-links": "hyperlink --canonicalroot https://frontend.design-system.service.gov.uk --internal --recursive build/index.html --skip 'property=\"og:image\"' | tee check-links.log | tap-mocha-reporter min"
   },
   "devDependencies": {
-    "govuk-frontend": "^5.11.1",
+    "govuk-frontend": "^5.11.2",
     "govuk-frontend-v4": "npm:govuk-frontend@^4.10.1",
     "hyperlink": "^5.0.4",
     "sassdoc": "^2.7.4",


### PR DESCRIPTION
Following the [5.11.2 release of GOV.UK Frontend](https://github.com/alphagov/govuk-frontend/releases/tag/v5.11.2)