### PR TITLE
Fix type of charactersAtLimit in index.html.md.erb

### DIFF
--- a/source/javascript-api-reference/index.html.md.erb
+++ b/source/javascript-api-reference/index.html.md.erb
@@ -231,7 +231,7 @@ Default:
 
 ##### wordsAtLimit
 
-Type: object
+Type: string
 
 Message displayed when the number of words reaches the configured maximum,
 `maxwords`. This message is displayed visually and through assistive


### PR DESCRIPTION
Type of charactersAtLimit is stated as `object` but default value is `'You have 0 characters remaining'` so suspect type should be `string`.

Type of wordsAtLimit is stated as `object` but default value is `'You have 0 words remaining'` so suspect type should be `string`.