### PR TITLE
Fix typo in error handler context and other suggestions

### DIFF
--- a/source/building-your-own-javascript-components/index.html.md.erb
+++ b/source/building-your-own-javascript-components/index.html.md.erb
@@ -218,7 +218,7 @@ The context object will contain the following properties:
 import { createAll } from 'govuk-frontend'
 import { ProjectComponent } from './project-component.js'
 
-function notifyErrorMonitoringService(error, { Component, element, config }) {
+function notifyErrorMonitoringService(error, { component, element, config }) {
   // Send relevant details to an error monitoring service
 }
 
@@ -238,7 +238,7 @@ import { ProjectComponent } from './project-component.js'
 
 const $element = document.querySelector('.app-dialog')
 
-function notifyErrorMonitoringService(error, { Component, element, config }) {
+function notifyErrorMonitoringService(error, { component, element, config }) {
   // Do something with initialisation error, like sending relevant details to an error monitoring service
 }
 

--- a/source/building-your-own-javascript-components/index.html.md.erb
+++ b/source/building-your-own-javascript-components/index.html.md.erb
@@ -387,7 +387,7 @@ class MyComponent extends ConfigurableComponent {
       // As `anOption` is left out of this object
       // it won’t be able to be overridden by `data-an-option`
       aNumberOption: {type: 'number'},
-      aBooleanOption: {type: 'boolean'}
+      aBooleanOption: {type: 'boolean'},
       // For nested objects, only the type of the root needs to be defined
       anOptionWithNesting: {type: 'object'}
     }

--- a/source/building-your-own-javascript-components/index.html.md.erb
+++ b/source/building-your-own-javascript-components/index.html.md.erb
@@ -386,10 +386,10 @@ class MyComponent extends ConfigurableComponent {
     properties: {
       // As `anOption` is left out of this object
       // it won’t be able to be overridden by `data-an-option`
-      aNumberOption: {type: 'number'},
-      aBooleanOption: {type: 'boolean'},
+      aNumberOption: { type: 'number' },
+      aBooleanOption: { type: 'boolean' },
       // For nested objects, only the type of the root needs to be defined
-      anOptionWithNesting: {type: 'object'}
+      anOptionWithNesting: { type: 'object' }
     }
   }
 

--- a/source/building-your-own-javascript-components/index.html.md.erb
+++ b/source/building-your-own-javascript-components/index.html.md.erb
@@ -224,7 +224,11 @@ function notifyErrorMonitoringService(error, { component, element, config }) {
   // Send relevant details to an error monitoring service
 }
 
-createAll(ProjectComponent, {SOME_CONFIGURATION}, notifyErrorMonitoringService)
+createAll(
+  ProjectComponent,
+  { SOME_CONFIGURATION },
+  notifyErrorMonitoringService
+)
 
 // If you don’t need any configuration, pass `undefined` for the configuration
 createAll(ProjectComponent, undefined, notifyErrorMonitoringService)

--- a/source/building-your-own-javascript-components/index.html.md.erb
+++ b/source/building-your-own-javascript-components/index.html.md.erb
@@ -203,9 +203,9 @@ createAll(ProjectComponent, undefined, $element)
 
 ### Handling initialisation errors
 
-By default, `createAll` catches errors thrown by components during their initialisation and logs them in the console. This makes sure components further down the page still get initialised after an error. You may still want to respond to errors as the components initialise, such as by notifying an error monitoring service, without [manually initialising each component](../import-javascript/#import-individual-components). 
+By default, both `createAll` and `initAll` catch errors thrown by components during their initialisation and log them in the console. This makes sure components further down the page still get initialised after an error. You may still want to respond to errors as the components initialise, such as by notifying an error monitoring service, without [manually initialising each component](../import-javascript/#import-individual-components). 
 
-You can use a function as a third argument to respond to errors being thrown while components are being initialised. If a component throws an error, the function will be called and will receive:
+To respond to errors being thrown while components are being initialised you can use a function as the third argument to `createAll` or the `{ onError }` option for `initAll`. If a component throws an error, the function will be called and will receive:
 
 - the error that was thrown
 - an object with some more context

--- a/source/building-your-own-javascript-components/index.html.md.erb
+++ b/source/building-your-own-javascript-components/index.html.md.erb
@@ -168,6 +168,7 @@ import { createAll } from 'govuk-frontend'
 import { ProjectComponent, OtherProjectComponent } from './project-components.js'
 
 createAll(ProjectComponent)
+
 // You can provide a config for components that use them
 createAll(OtherProjectComponent, {
   anOption: 'itsValue'
@@ -195,6 +196,7 @@ import { ProjectComponent } from './project-component.js'
 const $element = document.querySelector('.app-dialog')
 
 createAll(ProjectComponent, {SOME_CONFIGURATION}, $element)
+
 // If the component does not need any configuration, pass `undefined` for the configuration
 createAll(ProjectComponent, undefined, $element)
 ```
@@ -223,6 +225,7 @@ function notifyErrorMonitoringService(error, { component, element, config }) {
 }
 
 createAll(ProjectComponent, {SOME_CONFIGURATION}, notifyErrorMonitoringService)
+
 // If you don’t need any configuration, pass `undefined` for the configuration
 createAll(ProjectComponent, undefined, notifyErrorMonitoringService)
 ```
@@ -246,6 +249,7 @@ createAll(ProjectComponent, {SOME_CONFIGURATION}, {
   scope: $element,
   onError: notifyErrorMonitoringService
 })
+
 // If you don’t need any configuration, pass `undefined` for the configuration
 createAll(ProjectComponent, undefined, {
   scope: $element,

--- a/source/configure-components/index.html.md.erb
+++ b/source/configure-components/index.html.md.erb
@@ -54,7 +54,7 @@ createAll(CharacterCount, {
 
 Read the [JavaScript API Reference](../javascript-api-reference/) for the list of options in each component configuration.
 
-### Configure all components using the initAll function
+### Configure all components using the `initAll` function
 
 You can pass configuration for components when initialising GOV.UK Frontend using the `initAll` function.
 

--- a/source/import-javascript/index.html.md.erb
+++ b/source/import-javascript/index.html.md.erb
@@ -85,11 +85,11 @@ The `createAll` function will log any errors thrown during components instantiat
 ```javascript
 import { SkipLink, CharacterCount, createAll } from 'govuk-frontend'
 
-createAll(SkipLink, function(error) {
+createAll(SkipLink, (error) => {
   // Handle the error here, for example send it to an error monitoring service
 })
 // You can provide a config for components that use them
-createAll(CharacterCount, { maxLength: 500 }, function(error) {
+createAll(CharacterCount, { maxLength: 500 }, (error) => {
   // Handle the error here, for example send it to an error monitoring service
 })
 ```

--- a/source/import-javascript/index.html.md.erb
+++ b/source/import-javascript/index.html.md.erb
@@ -82,6 +82,7 @@ createAll(CharacterCount, { maxLength: 500 })
 
 The `createAll` and `initAll` functions will log any errors thrown during components instantiation to the console. If you need to handle these errors, you can use [their `{ onError }` option](../building-your-own-javascript-components/#handling-initialisation-errors).
 
+Handling errors from `createAll`:
 
 ```javascript
 import { SkipLink, CharacterCount, createAll } from 'govuk-frontend'
@@ -96,7 +97,20 @@ createAll(CharacterCount, { maxLength: 500 }, (error, context) => {
 })
 ```
 
-You can also initialise components manually.
+Handling errors from `initAll`:
+
+```javascript
+import { initAll } from 'govuk-frontend'
+
+initAll({
+  characterCount: { maxLength: 500 },
+  onError(error, context) {
+    // Handle the error here, for example send it to an error monitoring service
+  }
+})
+```
+
+You can also handle errors for manually initialised components:
 
 ```javascript
 import { SkipLink, CharacterCount } from 'govuk-frontend'

--- a/source/import-javascript/index.html.md.erb
+++ b/source/import-javascript/index.html.md.erb
@@ -86,12 +86,12 @@ The `createAll` function will log any errors thrown during components instantiat
 ```javascript
 import { SkipLink, CharacterCount, createAll } from 'govuk-frontend'
 
-createAll(SkipLink, (error) => {
+createAll(SkipLink, (error, context) => {
   // Handle the error here, for example send it to an error monitoring service
 })
 
 // You can provide a config for components that use them
-createAll(CharacterCount, { maxLength: 500 }, (error) => {
+createAll(CharacterCount, { maxLength: 500 }, (error, context) => {
   // Handle the error here, for example send it to an error monitoring service
 })
 ```

--- a/source/import-javascript/index.html.md.erb
+++ b/source/import-javascript/index.html.md.erb
@@ -113,7 +113,7 @@ $characterCounts.forEach(($characterCount) => {
   
   try {
     // You can provide a config for components that use them
-    new CharacterCount($characterCount, {maxLength: 500})
+    new CharacterCount($characterCount, { maxLength: 500 })
   } catch (error) {
     // Handle the error here, for example send it to an error monitoring service
   }

--- a/source/import-javascript/index.html.md.erb
+++ b/source/import-javascript/index.html.md.erb
@@ -80,7 +80,7 @@ createAll(CharacterCount, { maxLength: 500 })
 
 #### Handling errors during instantiation
 
-The `createAll` function will log any errors thrown during components instantiation to the console. If you need to catch these errors, you can use [its `{ onError }` option](../building-your-own-javascript-components/#handling-initialisation-errors).
+The `createAll` function will log any errors thrown during components instantiation to the console. If you need to handle these errors, you can use [its `{ onError }` option](../building-your-own-javascript-components/#handling-initialisation-errors).
 
 
 ```javascript

--- a/source/import-javascript/index.html.md.erb
+++ b/source/import-javascript/index.html.md.erb
@@ -73,6 +73,7 @@ To improve how quickly your service’s pages load in browsers, import only the 
 import { SkipLink, CharacterCount, createAll } from 'govuk-frontend'
 
 createAll(SkipLink)
+
 // You can provide a config for components that use them
 createAll(CharacterCount, { maxLength: 500 })
 ```
@@ -88,6 +89,7 @@ import { SkipLink, CharacterCount, createAll } from 'govuk-frontend'
 createAll(SkipLink, (error) => {
   // Handle the error here, for example send it to an error monitoring service
 })
+
 // You can provide a config for components that use them
 createAll(CharacterCount, { maxLength: 500 }, (error) => {
   // Handle the error here, for example send it to an error monitoring service
@@ -110,7 +112,6 @@ $skipLinks.forEach(($skipLink) => {
 
 const $characterCounts = document.querySelectorAll('[data-module="govuk-character-count"]')
 $characterCounts.forEach(($characterCount) => {
-  
   try {
     // You can provide a config for components that use them
     new CharacterCount($characterCount, { maxLength: 500 })

--- a/source/import-javascript/index.html.md.erb
+++ b/source/import-javascript/index.html.md.erb
@@ -80,7 +80,7 @@ createAll(CharacterCount, { maxLength: 500 })
 
 #### Handling errors during instantiation
 
-The `createAll` function will log any errors thrown during components instantiation to the console. If you need to handle these errors, you can use [its `{ onError }` option](../building-your-own-javascript-components/#handling-initialisation-errors).
+The `createAll` and `initAll` functions will log any errors thrown during components instantiation to the console. If you need to handle these errors, you can use [their `{ onError }` option](../building-your-own-javascript-components/#handling-initialisation-errors).
 
 
 ```javascript

--- a/source/import-javascript/index.html.md.erb
+++ b/source/import-javascript/index.html.md.erb
@@ -80,7 +80,7 @@ createAll(CharacterCount, { maxLength: 500 })
 
 #### Handling errors during instantiation
 
-The `createAll` function will log any errors thrown during components instantiation to the console. If you need to catch these errors, you can use [its `onError` option](../building-your-own-javascript-components/#handling-initialisation-errors).
+The `createAll` function will log any errors thrown during components instantiation to the console. If you need to catch these errors, you can use [its `{ onError }` option](../building-your-own-javascript-components/#handling-initialisation-errors).
 
 
 ```javascript
@@ -154,7 +154,7 @@ createAll(CharacterCount, { maxLength: 500 }, $element)
 
 ### Initialise all components on part of a page
 
-Run `initAll` with a `scope` parameter to initialise the components on part of a page:
+Run `initAll` with a `{ scope }` option to initialise the components on part of a page:
 
 ```javascript
 import { initAll } from 'govuk-frontend'

--- a/source/import-javascript/index.html.md.erb
+++ b/source/import-javascript/index.html.md.erb
@@ -96,7 +96,7 @@ createAll(CharacterCount, { maxLength: 500 }, (error, context) => {
 })
 ```
 
-You can also instantiate components manually.
+You can also initialise components manually.
 
 ```javascript
 import { SkipLink, CharacterCount } from 'govuk-frontend'

--- a/source/javascript-api-reference/index.html.md.erb
+++ b/source/javascript-api-reference/index.html.md.erb
@@ -266,7 +266,7 @@ Default:
 
 Type: object
 
-Message made available to assistive technologies, if none is already present in the HTML, to describe that the component accepts only a limited amount of content. The component will replace the `%{count}` placeholder with the value of the `maxlength` or `maxwords` parameter.
+Message made available to assistive technologies, if none is already present in the HTML, to describe that the component accepts only a limited amount of content. The component will replace the `%{count}` placeholder with the value of the `maxlength` or `maxwords` option.
 
 Default:
 

--- a/source/localise-govuk-frontend/index.html.md.erb
+++ b/source/localise-govuk-frontend/index.html.md.erb
@@ -119,7 +119,7 @@ With data attributes
 
 ```html
 <div
-  data-module="character-count"
+  data-module="govuk-character-count"
   data-i18n.characters-under-limit.other="%{count} characters to go"
   data-i18n.characters-under-limit.one="One character to go"
   data-i18n.characters-over-limit.one="One character too many"

--- a/source/v4/importing-css-assets-and-javascript/index.html.md.erb
+++ b/source/v4/importing-css-assets-and-javascript/index.html.md.erb
@@ -214,7 +214,7 @@ GOVUKFrontend.initAll()
 
 ### Select and initialise part of a page
 
-If you update a page with new markup, for example a modal dialogue box, you can run `initAll` with a `scope` parameter to initialise the components on part of a page.
+If you update a page with new markup, for example a modal dialogue box, you can run `initAll` with a `{ scope }` option to initialise the components on part of a page.
 
 For example:
 

--- a/source/v4/javascript-api-reference/index.html.md.erb
+++ b/source/v4/javascript-api-reference/index.html.md.erb
@@ -277,7 +277,7 @@ Default:
 
 Type: object
 
-Message made available to assistive technologies, if none is already present in the HTML, to describe that the component accepts only a limited amount of content. The component will replace the `%{count}` placeholder with the value of the `maxlength` or `maxwords` parameter.
+Message made available to assistive technologies, if none is already present in the HTML, to describe that the component accepts only a limited amount of content. The component will replace the `%{count}` placeholder with the value of the `maxlength` or `maxwords` option.
 
 Default:
 

--- a/source/v4/javascript-api-reference/index.html.md.erb
+++ b/source/v4/javascript-api-reference/index.html.md.erb
@@ -19,7 +19,7 @@ For example, to set the `preventDoubleClick` option of a button:
 
 ```javascript
 // Creating a single instance
-var button = document.querySelector('[data-module="button"]')
+var button = document.querySelector('[data-module="govuk-button"]')
 new GOVUKFrontend.Button(button, {preventDoubleClick: true})
 
 // Or when using initAll

--- a/source/v4/localise-govuk-frontend/index.html.md.erb
+++ b/source/v4/localise-govuk-frontend/index.html.md.erb
@@ -118,7 +118,7 @@ With Nunjucks
 With data attributes
 
 ```html
-<div data-module="character-count" 
+<div data-module="govuk-character-count" 
   data-i18n.characters-under-limit.other="%{count} characters to go"
   data-i18n.characters-under-limit.one="One character to go"
   data-i18n.characters-over-limit.one="One character too many">


### PR DESCRIPTION
This PR aimed to fix a ~`Component`~ `component` typo in the error handler example:

```patch
- function notifyErrorMonitoringService(error, { Component, element, config }) {
+ function notifyErrorMonitoringService(error, { component, element, config }) {
```

But I also noticed an incorrect link to copying assets and some other minor improvements