### PR TITLE
Replace links to the website get-in-touch page to contact

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: Get in touch another way
-    url: https://design-system.service.gov.uk/get-in-touch/
+    url: https://design-system.service.gov.uk/contact/
     about: Find out how to get in touch via email or Slack

--- a/source/404.html.md.erb
+++ b/source/404.html.md.erb
@@ -12,4 +12,4 @@ If you typed the web address, check it is correct.
 
 If you pasted the web address, check you copied the entire address.
 
-[Contact the Design System team](https://design-system.service.gov.uk/get-in-touch/) if you believe you are seeing this message in error.
+[Contact the Design System team](https://design-system.service.gov.uk/contact/) if you believe you are seeing this message in error.

--- a/source/errors/generic.html.md.erb
+++ b/source/errors/generic.html.md.erb
@@ -10,4 +10,4 @@ layout: core
 
 Try again later.
 
-[Contact the Design System team](https://design-system.service.gov.uk/get-in-touch/) if you believe you are seeing this message in error.
+[Contact the Design System team](https://design-system.service.gov.uk/contact/) if you believe you are seeing this message in error.

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -20,4 +20,4 @@ You can also use the option to [copy and install precompiled files](/install-usi
 
 There are live examples of GOV.UK Frontend components, and guidance on using them in your service, in the [GOV.UK Design System](https://design-system.service.gov.uk/).
 
-[Contact us](https://design-system.service.gov.uk/get-in-touch/) if you have any questions or feedback.
+[Contact us](https://design-system.service.gov.uk/contact/) if you have any questions or feedback.

--- a/source/v4/index.html.md.erb
+++ b/source/v4/index.html.md.erb
@@ -23,4 +23,4 @@ Use this technical documentation to find out how to:
 
 Use the [GOV.UK Design System](https://design-system.service.gov.uk/) site to see live examples of GOV.UK Frontend components and guidance on how and when to use them in your service.
 
-[Contact us](https://design-system.service.gov.uk/get-in-touch/) if you have any questions or feedback.
+[Contact us](https://design-system.service.gov.uk/contact/) if you have any questions or feedback.


### PR DESCRIPTION
Replaces links to `https://design-system.service.gov.uk/get-in-touch/` with `https://design-system.service.gov.uk/contact/`

Doing in response to https://github.com/alphagov/govuk-design-system/pull/5068. This isn't the biggest deal since we redirect but is the neater option.