### PR TITLE
Add npm start script that starts the middleman server

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "name": "govuk-frontend-docs",
   "version": "1.0.0",
   "scripts": {
+    "start": "bundle exec middleman server",
     "postinstall": "npm run build:sassdoc && npm run build:sassdocv4",
     "build:sassdoc": "sassdoc --no-update-notifier --parse node_modules/govuk-frontend/dist/govuk/ > data/sassdoc.json",
     "build:sassdocv4": "sassdoc --no-update-notifier --parse node_modules/govuk-frontend-v4/govuk/ > data/sassdoc-v4.json",


### PR DESCRIPTION
It's a slight annoyance having to remember/look up the command to start the middleman server, but the team is used to running `npm start`, so this creates a start script that runs the middleman command.