### PR TITLE
Remove trailing `/index` of `@import` statements in v6.0.0 docs

### DIFF
--- a/source/import-css/index.html.md.erb
+++ b/source/import-css/index.html.md.erb
@@ -55,36 +55,36 @@ You must import the layers in the order listed in the example below.
 // Basic content styles for typography, links etc. Approximately 10% of
 // the CSS output if you include everything.
 
-@import "node_modules/govuk-frontend/dist/govuk/core/index";
+@import "node_modules/govuk-frontend/dist/govuk/core";
 
 // Objects include things like the page template, grid and form groups.
 // Approximately 5% of the CSS output if you include everything.
 
-@import "node_modules/govuk-frontend/dist/govuk/objects/index";
+@import "node_modules/govuk-frontend/dist/govuk/objects";
 
 // The components themselves - try to only include the components you
 // are using in your project. Approximately 70% of the CSS output if
 // you include everything.
 
 <% components.each do |component| %>
-@import "node_modules/govuk-frontend/dist/govuk/components/<%= component %>/index";
+@import "node_modules/govuk-frontend/dist/govuk/components/<%= component %>";
 <% end %>
 
 /*
 // Alternatively, you can import all components:
-@import "node_modules/govuk-frontend/dist/govuk/components/index";
+@import "node_modules/govuk-frontend/dist/govuk/components";
 */
 
 // Utilities, for example govuk-clearfix or govuk-visually-hidden.
 // Approximately 1% of the CSS output if you include everything.
 
-@import "node_modules/govuk-frontend/dist/govuk/utilities/index";
+@import "node_modules/govuk-frontend/dist/govuk/utilities";
 
 // Overrides, used to adjust things like the amount of spacing on an
 // element. Override classes always include `-!-` in the class name.
 // Approximately 15% of the CSS output if you include everything.
 
-@import "node_modules/govuk-frontend/dist/govuk/overrides/index";
+@import "node_modules/govuk-frontend/dist/govuk/overrides";
 
 /*
 // Alternatively, you can import the specific groups of overrides

--- a/source/installing-with-npm/index.html.md.erb
+++ b/source/installing-with-npm/index.html.md.erb
@@ -64,7 +64,7 @@ The accordion will use a generic font until you get the font and images working,
 There are also different ways you can [import GOV.UK Frontend's CSS](../import-css/), including into your project's main Sass file:
 
 ```scss
-@import "node_modules/govuk-frontend/dist/govuk/index";
+@import "node_modules/govuk-frontend/dist/govuk";
 ```
 
 ### Get the font and images working


### PR DESCRIPTION
v6.0.0 only supports Dart Sass 1.79+, which will automatically loads the `index.scss` or `_index.scss` files if the path resolves to a folder.

Only the content of the v6.0.0 docs has been updated, as v5.0.0 and v4.0.0 still support Ruby Sass and LibSass which would need the full path to the imported file.

Fixes #600 