### PR TITLE
Exclude import-only files from Sassdoc

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "scripts": {
     "start": "bundle exec middleman server",
     "postinstall": "npm run build:sassdoc && npm run build:sassdocv5 && npm run build:sassdocv4",
-    "build:sassdoc": "sassdoc --no-update-notifier --parse node_modules/govuk-frontend/dist/govuk/ > data/sassdoc.json",
-    "build:sassdocv5": "sassdoc --no-update-notifier --parse node_modules/govuk-frontend-v5/dist/govuk/ > data/sassdoc-v5.json",
-    "build:sassdocv4": "sassdoc --no-update-notifier --parse node_modules/govuk-frontend-v4/govuk/ > data/sassdoc-v4.json",
+    "build:sassdoc": "sassdoc -c sassdoc.config.json --parse node_modules/govuk-frontend/dist/govuk/ > data/sassdoc.json",
+    "build:sassdocv5": "sassdoc -c sassdoc.config.json --parse node_modules/govuk-frontend-v5/dist/govuk/ > data/sassdoc-v5.json",
+    "build:sassdocv4": "sassdoc -c sassdoc.config.json --parse node_modules/govuk-frontend-v4/govuk/ > data/sassdoc-v4.json",
     "lint": "standard",
     "check-links": "hyperlink --canonicalroot https://frontend.design-system.service.gov.uk --internal --recursive build/index.html --skip 'property=\"og:image\"' --skip 'application.js' | tee check-links.log | tap-mocha-reporter min"
   },

--- a/sassdoc.config.json
+++ b/sassdoc.config.json
@@ -1,0 +1,4 @@
+{
+  "exclude": ["**/*.import.scss"],
+  "no-update-notifier": true
+}


### PR DESCRIPTION
v6.2.0 adds import only files in GOV.UK Frontend, some of which have duplicate the Sass documentation from their corresponding Sass module. To avoid duplicating entries in the Sass API, we use a `sassdoc.config.json` file to exclude the `.import.scss` file.

Unfortunately, there's [no flag for Sassdoc's CLI to exclude files](http://sassdoc.com/getting-started/#options) and working out a glob pattern would make things a little cryptic.