### PR TITLE
Fix contrast issues with comments in code examples

### DIFF
--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -4,3 +4,12 @@
 .technical-documentation .table-container td > code {
   white-space: nowrap;
 }
+
+// Temporarily override syntax highlighting to fix poor contrast for comments.
+.highlight .c,
+.highlight .cm,
+.highlight .cp,
+.highlight .c1,
+.highlight .cs { /* Comment.Special */
+  color: govuk-functional-colour(secondary-text);
+}


### PR DESCRIPTION
The colours were updated to better [match version 6 but for comments they were mistakenly set to the wrong colour](https://github.com/alphagov/tech-docs-gem/pull/442/changes/f09a4b8673fef2150e7aca18c4cc120774329656#diff-81435f36c443c406a3436b0531a4991cd20655917ede750cec10d5b2c6b3bdcf).

This results in comments that are very hard to read.

I have put in a quick patch here to resolve the issue immediately and will upstream this patch into the tech-docs-gem.

## Screenshots
### Before
![Screenshot of code example with comments that have very low contrast](https://github.com/user-attachments/assets/43cf2cdd-9e4d-4b9b-a982-16b6dc502d63) 

### After
![Screenshot of code example with comments that have very low contrast](https://github.com/user-attachments/assets/4a33be12-59c3-4415-9a6b-ed731ceebbb5)