### PR TITLE
Remove temporary fix for unreadable comments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem "tzinfo-data", platforms: %i[mswin mingw jruby]
 gem "logger"
 
 # Include the tech docs gem
-gem "govuk_tech_docs", "~> 6.1.0"
+gem "govuk_tech_docs", "~> 6.2.1"
 
 # Development
 gem "json"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,26 +90,24 @@ GEM
     google-protobuf (4.34.1-x86_64-linux-musl)
       bigdecimal
       rake (~> 13.3)
-    govuk_tech_docs (6.1.0)
-      autoprefixer-rails (~> 10.2)
-      base64
-      bigdecimal
-      chronic (~> 0.10.2)
-      concurrent-ruby (= 1.3.4)
+    govuk_tech_docs (6.2.1)
+      autoprefixer-rails
+      chronic
+      concurrent-ruby
       csv
       haml (~> 6.0)
-      middleman (~> 4.6.1)
-      middleman-autoprefixer (~> 2.10)
-      middleman-compass (~> 4.0)
+      middleman
+      middleman-autoprefixer
+      middleman-compass
       middleman-livereload
       middleman-search-gds
-      middleman-sprockets (~> 4.0.0)
-      middleman-syntax (~> 3.6)
+      middleman-sprockets (= 4.0.0)
+      middleman-syntax
       mutex_m
       nokogiri
-      openapi3_parser (~> 0.10.1)
-      redcarpet (~> 3.6)
-      sassc-embedded (~> 1.78.0)
+      openapi3_parser
+      redcarpet
+      sassc-embedded
       schmooze (~> 0.2.0)
       terser (~> 1.2.3)
     haml (6.4.0)
@@ -349,7 +347,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  govuk_tech_docs (~> 6.1.0)
+  govuk_tech_docs (~> 6.2.1)
   json
   logger
   ostruct

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -4,12 +4,3 @@
 .technical-documentation .table-container td > code {
   white-space: nowrap;
 }
-
-// Temporarily override syntax highlighting to fix poor contrast for comments.
-.highlight .c,
-.highlight .cm,
-.highlight .cp,
-.highlight .c1,
-.highlight .cs { /* Comment.Special */
-  color: govuk-functional-colour(secondary-text);
-}


### PR DESCRIPTION
This is now upstream in 6.2.1 of the tech docs gem.

Closes https://github.com/alphagov/govuk-frontend-docs/issues/618