### PR TITLE
Fix missing bullet points on 'Using GOV.UK Frontend without GOV.UK branding'

### DIFF
--- a/source/using-govuk-frontend-without-govuk-branding/index.html.md.erb
+++ b/source/using-govuk-frontend-without-govuk-branding/index.html.md.erb
@@ -9,8 +9,8 @@ weight: 99
 
 This guidance is aimed at services that are: 
 
-using GOV.UK patterns and frontend code
-not part of the GOV.UK website
+- using GOV.UK patterns and frontend code
+- not part of the GOV.UK website
 
 You must be using [GOV.UK Frontend v6.3.0](https://github.com/alphagov/govuk-frontend/releases/tag/v6.3.0) or later to follow the steps in this guidance. If you’re using an earlier version of GOV.UK Frontend than v6.0.0, see the [v6.0.0 release notes](https://github.com/alphagov/govuk-frontend/releases/tag/v6.0.0) for information on how to upgrade to that major version. 
 


### PR DESCRIPTION
[Add missing bullet points in the introduction section](https://deploy-preview-637--govuk-frontend-docs-preview.netlify.app/using-govuk-frontend-without-govuk-branding/).