### PR TITLE
Fix typo in unbranding Frontend guidance

### DIFF
--- a/source/using-govuk-frontend-without-govuk-branding/index.html.md.erb
+++ b/source/using-govuk-frontend-without-govuk-branding/index.html.md.erb
@@ -64,7 +64,7 @@ You can use [Sass’s `@use… with` syntax](https://sass-lang.com/documentation
 
 ```scss
 @use "pkg:govuk-frontend" as * with (
-  $govuk-font-family: (“Helvetica Heue”, Helvetica, Arial, sans-serif),
+  $govuk-font-family: (“Helvetica Neue”, Helvetica, Arial, sans-serif),
   $govuk-functional-colours: (
     brand: [your new brand colour]
   )


### PR DESCRIPTION
It should be `Helvetica Neue`, not `Helvetica Heue`