### PR TITLE
Fix indexing of pages

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -19,8 +19,8 @@ activate :header_menu_fix
 # from an outdated version the time for the tech_docs_gem to catch up
 sprockets.prepend_path File.join(__dir__, "./node_modules/govuk-frontend/")
 
-# Prevent pages from being indexed unless GitHub Actions is building the main branch
-config[:tech_docs][:prevent_indexing] = (ENV["GITHUB_REF"] != "refs/heads/main")
+# Prevent pages from being indexed unless Netlify is building the main branch
+config[:tech_docs][:prevent_indexing] = (ENV["CONTEXT"] != "production")
 
 helpers do
   include PackageContents


### PR DESCRIPTION
When we migrated to Netlify we didnt change the logic that checks if the project is deployed to production.

This means the pages are currently not indexed.

By checking the `CONTEXT` environment variable supplied by Netlify (https://docs.netlify.com/build/configure-builds/environment-variables/#build-metadata) we can only prevent indexing if the project is not deployed to `production`.

Found when searching `govuk frontend docs` and then `site:frontend.design-system.service.gov.uk` not returning any results.

